### PR TITLE
ci: Bump codecov/codecov-action to v3

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -48,7 +48,7 @@ jobs:
       run: if [ "${CC}" = "gcc" ]; then make code-coverage-capture; fi
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v2
+      uses: codecov/codecov-action@v3
       with:
         verbose: true
 


### PR DESCRIPTION
The v2 version uses node12 which is deprecated.