### PR TITLE
Add matrix support in the benchmark disk command

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -34,10 +34,5 @@ jobs:
     - uses: bencherdev/bencher@v0.3.6
     - name: Benchmark with Bencher
       run: |
-          for engine in pwritev2 uring kaio; do
-            for buf in 4096 65536; do
-              for mode in buffered direct; do
-                ./benchmark/run disk -e $engine -b $buf -m $mode
-              done
-            done
-          done | bencher run --project raft
+          bencher run --project raft \
+            "./benchmark/run disk -e uring,kaio,pwritev2 -b 4096,65536,262144 -m direct,buffered"

--- a/benchmark/disk_kaio.c
+++ b/benchmark/disk_kaio.c
@@ -81,9 +81,11 @@ int DiskWriteUsingKaio(int fd, struct iovec *iov, unsigned n, time_t *latencies)
     unsigned i;
     int rv;
 
+    memset(&ctx, 0, sizeof ctx);
+
     rv = io_setup(1, &ctx);
     if (rv != 0) {
-        fprintf(stderr, "io_setup: %s\n", strerror(rv));
+        perror("io_setup");
         return -1;
     }
 
@@ -98,7 +100,7 @@ int DiskWriteUsingKaio(int fd, struct iovec *iov, unsigned n, time_t *latencies)
 
     rv = io_destroy(ctx);
     if (rv != 0) {
-        fprintf(stderr, "io_destroy: %s\n", strerror(rv));
+        perror("io_destroy");
         return -1;
     }
 

--- a/benchmark/disk_parse.c
+++ b/benchmark/disk_parse.c
@@ -1,10 +1,14 @@
 #include <argp.h>
+#include <assert.h>
 #include <stdlib.h>
+#include <string.h>
 
 #include "disk.h"
-#include "disk_options.h"
+#include "disk_parse.h"
 
-static char doc[] = "Benchmark sequential write performance";
+static char doc[] =
+    "Benchmark sequential write performance\n\n"
+    "Each option can be passed multiple comma-separated arguments.\n";
 
 /* Order of fields: {NAME, KEY, ARG, FLAGS, DOC, GROUP}.*/
 static struct argp_option options[] = {
@@ -23,27 +27,87 @@ static struct argp argp = {
     .doc = doc,
 };
 
+/* Expand the run options in the given matrix by multiplying them by the given
+ * factor. */
+static void expandMatrix(struct diskMatrix *matrix, unsigned factor)
+{
+    unsigned n_opts = matrix->n_opts * factor;
+    unsigned i;
+    unsigned j;
+    assert(factor > 1);
+    matrix->opts = realloc(matrix->opts, n_opts * sizeof *matrix->opts);
+    assert(matrix->opts != NULL);
+
+    /* Create copies of the original options. */
+    for (i = 1; i < factor; i++) {
+        for (j = 0; j < matrix->n_opts; j++) {
+            matrix->opts[i * matrix->n_opts + j] = matrix->opts[j];
+        }
+    }
+
+    matrix->n_opts = n_opts;
+}
+
 static error_t argpParser(int key, char *arg, struct argp_state *state)
 {
-    struct diskOptions *opts = state->input;
-    switch (key) {
-        case 'd':
-            opts->dir = arg;
-            break;
-        case 'b':
-            opts->buf = (size_t)atoi(arg);
-            break;
-        case 's':
-            opts->size = (unsigned)atoi(arg);
-            break;
-        case 'e':
-            opts->engine = DiskEngineCode(arg);
-            break;
-        case 'm':
-            opts->mode = DiskModeCode(arg);
-            break;
-        default:
-            return ARGP_ERR_UNKNOWN;
+    struct diskMatrix *matrix = state->input;
+    struct diskOptions *opts;
+    char *token;
+    unsigned n_opts = matrix->n_opts; /* Original size of the matrix */
+    unsigned n_tokens = 1;
+    unsigned i;
+    unsigned j;
+    unsigned k;
+
+    /* All our flags require and argument. So if there's no argument, this is
+     * not a supported flag. */
+    if (arg == NULL) {
+        return ARGP_ERR_UNKNOWN;
+    }
+
+    /* Count the number of comma-separated tokens in this argument. */
+    for (i = 0; i < strlen(arg); i++) {
+        if (arg[i] == ',')
+            n_tokens++;
+    }
+
+    /* Multiply the matrix by the number of tokens. */
+    if (n_tokens > 1) {
+        expandMatrix(matrix, n_tokens);
+    }
+
+    k = 0;
+    for (i = 0; i < n_tokens; i++) {
+        if (i == 0) {
+            token = strtok(arg, ",");
+        } else {
+            token = strtok(NULL, ",");
+        }
+        assert(token != NULL);
+
+        for (j = 0; j < n_opts; j++) {
+            opts = &matrix->opts[k];
+            k++;
+            switch (key) {
+                case 'd':
+                    opts->dir = token;
+                    break;
+                case 'b':
+                    opts->buf = (size_t)atoi(token);
+                    break;
+                case 's':
+                    opts->size = (unsigned)atoi(token);
+                    break;
+                case 'e':
+                    opts->engine = DiskEngineCode(token);
+                    break;
+                case 'm':
+                    opts->mode = DiskModeCode(token);
+                    break;
+                default:
+                    return ARGP_ERR_UNKNOWN;
+            }
+        }
     }
 
     return 0;
@@ -58,11 +122,21 @@ static void optionsInit(struct diskOptions *opts)
     opts->mode = DISK_MODE_DIRECT;
 }
 
-void DiskParse(int argc, char *argv[], struct diskOptions *opts)
+void DiskParse(int argc, char *argv[], struct diskMatrix *matrix)
 {
+    struct diskOptions *opts;
+
+    matrix->opts = malloc(sizeof *matrix->opts);
+    assert(matrix->opts != NULL);
+    matrix->n_opts = 1;
+
+    opts = matrix->opts;
     optionsInit(opts);
+
     argv[0] = "benchmark/run disk";
-    argp_parse(&argp, argc, argv, 0, 0, opts);
+    argp_parse(&argp, argc, argv, 0, 0, matrix);
+
+    return;
 
     if (opts->buf == 0) {
         printf("Invalid buffer size %zu\n", opts->buf);

--- a/benchmark/disk_parse.h
+++ b/benchmark/disk_parse.h
@@ -5,7 +5,14 @@
 
 #include "disk_options.h"
 
+/* Array of all options combination to run. */
+struct diskMatrix
+{
+    struct diskOptions *opts;
+    unsigned n_opts;
+};
+
 /* Parse the given command line arguments. */
-void DiskParse(int argc, char *argv[], struct diskOptions *opts);
+void DiskParse(int argc, char *argv[], struct diskMatrix *matrix);
 
 #endif /* DISK_ARGS_H_ */


### PR DESCRIPTION
This allows running multiple scenarios with a single command invokation.