### PR TITLE
Add "submit" command to raft-benchmark

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -27,7 +27,7 @@ jobs:
         BENCHER_TESTBED: github-ubuntu-22-04
         ENGINES: pwrite,kaio,uring
         MODES: direct,buffer
-        BUFSIZES: 4096,65536
+        BUFSIZES: 4096,8192,65536
       run: |
           bencher run --project raft --testbed $BENCHER_TESTBED \
             "raft-benchmark disk -e $ENGINES -m $MODES -b $BUFSIZES"
@@ -136,7 +136,7 @@ jobs:
         BENCHER_TESTBED: bmc-s1-c1-medium-${{ matrix.filesystem }}
         ENGINES: pwrite,kaio,uring
         MODES: direct,buffer
-        BUFSIZES: 4096,65536,262144,1048576
+        BUFSIZES: 4096,8192,65536,262144
       run: |
           bencher run --project raft --testbed ${BENCHER_TESTBED} \
             "$SSH raft-benchmark disk -d /mnt -e $ENGINES -m $MODES -b $BUFSIZES"

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -31,6 +31,8 @@ jobs:
       run: |
           bencher run --project raft --testbed $BENCHER_TESTBED \
             "raft-benchmark disk -e $ENGINES -m $MODES -b $BUFSIZES"
+          bencher run --project raft --testbed $BENCHER_TESTBED \
+            "raft-benchmark submit"
 
   bmc-deploy:
     name: On BMC - deploy
@@ -140,6 +142,8 @@ jobs:
       run: |
           bencher run --project raft --testbed ${BENCHER_TESTBED} \
             "$SSH raft-benchmark disk -d /mnt -e $ENGINES -m $MODES -b $BUFSIZES"
+          bencher run --project raft --testbed ${BENCHER_TESTBED} \
+            "$SSH raft-benchmark submit -d /mnt"
     - name: Cleanup
       run: |
         $SSH sudo umount /mnt

--- a/Makefile.am
+++ b/Makefile.am
@@ -252,12 +252,12 @@ bin_PROGRAMS += \
 
 tools_raft_benchmark_SOURCES = \
   tools/benchmark/disk.c \
-  tools/benchmark/disk_fs.c \
   tools/benchmark/disk_options.c \
   tools/benchmark/disk_parse.c \
   tools/benchmark/disk_pwrite.c \
   tools/benchmark/disk_uring.c \
   tools/benchmark/disk_kaio.c \
+  tools/benchmark/fs.c \
   tools/benchmark/main.c \
   tools/benchmark/report.c \
   tools/benchmark/timer.c

--- a/Makefile.am
+++ b/Makefile.am
@@ -260,8 +260,11 @@ tools_raft_benchmark_SOURCES = \
   tools/benchmark/fs.c \
   tools/benchmark/main.c \
   tools/benchmark/report.c \
+  tools/benchmark/submit_parse.c \
+  tools/benchmark/submit.c \
   tools/benchmark/timer.c
 tools_raft_benchmark_LDFLAGS =
+tools_raft_benchmark_LDADD = libraft.la $(UV_LIBS)
 
 endif # BENCHMARK_ENABLED
 

--- a/tools/benchmark/disk.c
+++ b/tools/benchmark/disk.c
@@ -16,12 +16,6 @@
 #include "disk_uring.h"
 #include "timer.h"
 
-/* Use the 0.50 percentile for reports. See:
- *
- * https://www.elastic.co/blog/averages-can-dangerous-use-percentile
- */
-#define PERCENTILE 0.50
-
 /* Allocate a buffer of the given size. */
 static void allocBuffer(struct iovec *iov, size_t size)
 {
@@ -37,29 +31,13 @@ static void allocBuffer(struct iovec *iov, size_t size)
     }
 }
 
-static int compareLatencies(const void *a, const void *b)
-{
-    const time_t *ta = (const time_t *)a;
-    const time_t *tb = (const time_t *)b;
-
-    return (*ta > *tb) - (*ta < *tb);
-}
-
 static void reportLatency(struct benchmark *benchmark,
                           time_t *latencies,
                           unsigned n)
 {
     struct metric *m;
-    unsigned i;
-
     m = BenchmarkGrow(benchmark, METRIC_KIND_LATENCY);
-
-    qsort(latencies, n, sizeof *latencies, compareLatencies);
-    i = (unsigned)((double)(n)*PERCENTILE);
-
-    m->value = (double)latencies[i];
-    m->lower_bound = (double)latencies[0];
-    m->upper_bound = (double)latencies[n - 1];
+    MetricFillLatency(m, latencies, n);
 }
 
 static void reportThroughput(struct benchmark *benchmark,
@@ -67,10 +45,9 @@ static void reportThroughput(struct benchmark *benchmark,
                              unsigned size)
 {
     struct metric *m;
-    double megabytes = (double)size / (1024 * 1024); /* N megabytes written */
-    double seconds = (double)duration / (1024 * 1024 * 1024);
+    unsigned megabytes = size / (1024 * 1024); /* N megabytes written */
     m = BenchmarkGrow(benchmark, METRIC_KIND_THROUGHPUT);
-    m->value = megabytes / seconds; /* Megabytes per second */
+    MetricFillThroughput(m, megabytes, duration);
 }
 
 /* Benchmark sequential write performance. */

--- a/tools/benchmark/disk.c
+++ b/tools/benchmark/disk.c
@@ -8,12 +8,12 @@
 #include <sys/types.h>
 
 #include "disk.h"
-#include "disk_fs.h"
 #include "disk_kaio.h"
 #include "disk_options.h"
 #include "disk_parse.h"
 #include "disk_pwrite.h"
 #include "disk_uring.h"
+#include "fs.h"
 #include "timer.h"
 
 /* Allocate a buffer of the given size. */
@@ -64,13 +64,13 @@ static int writeFile(struct diskOptions *opts, struct benchmark *benchmark)
 
     assert(opts->size % opts->buf == 0);
 
-    rv = DiskFsCreateTempFile(opts->dir, n * opts->buf, &path, &fd);
+    rv = FsCreateTempFile(opts->dir, n * opts->buf, &path, &fd);
     if (rv != 0) {
         return -1;
     }
 
     if (opts->mode == DISK_MODE_DIRECT) {
-        rv = DiskFsSetDirectIO(fd);
+        rv = FsSetDirectIO(fd);
         if (rv != 0) {
             return -1;
         }
@@ -108,7 +108,7 @@ static int writeFile(struct diskOptions *opts, struct benchmark *benchmark)
     reportThroughput(benchmark, duration, opts->size);
     free(latencies);
 
-    rv = DiskFsRemoveTempFile(path, fd);
+    rv = FsRemoveTempFile(path, fd);
     if (rv != 0) {
         return -1;
     }
@@ -140,7 +140,7 @@ int DiskRun(int argc, char *argv[], struct report *report)
         assert(opts->mode >= 0);
 
         if (opts->mode == DISK_MODE_DIRECT) {
-            rv = DiskFsCheckDirectIO(opts->dir, opts->buf);
+            rv = FsCheckDirectIO(opts->dir, opts->buf);
             if (rv != 0) {
                 goto err;
             }

--- a/tools/benchmark/fs.c
+++ b/tools/benchmark/fs.c
@@ -14,7 +14,7 @@
 /* Maximum physical block size for direct I/O that we expect to detect. */
 #define MAX_BLOCK_SIZE (1024 * 1024) /* 1M */
 
-static char *makeTempFileTemplate(const char *dir)
+static char *makeTempTemplate(const char *dir)
 {
     char *path;
     path = malloc(strlen(dir) + strlen("/bench-XXXXXX") + 1);
@@ -29,7 +29,7 @@ int FsCreateTempFile(const char *dir, size_t size, char **path, int *fd)
     int flags = O_WRONLY | O_CREAT | O_EXCL;
     int rv;
 
-    *path = makeTempFileTemplate(dir);
+    *path = makeTempTemplate(dir);
     *fd = mkostemp(*path, flags);
     if (*fd == -1) {
         printf("mstemp '%s': %s\n", *path, strerror(errno));
@@ -77,6 +77,19 @@ int FsRemoveTempFile(char *path, int fd)
 out:
     free(path);
     return rv;
+}
+
+int FsCreateTempDir(const char *dir, char **path)
+{
+    *path = makeTempTemplate(dir);
+    if (*path == NULL) {
+        return -1;
+    }
+    *path = mkdtemp(*path);
+    if (*path == NULL) {
+        return -1;
+    }
+    return 0;
 }
 
 /* Detect all suitable block size we can use to write to the underlying device

--- a/tools/benchmark/fs.c
+++ b/tools/benchmark/fs.c
@@ -1,6 +1,7 @@
 #include <assert.h>
 #include <errno.h>
 #include <fcntl.h>
+#include <ftw.h>
 #include <stdio.h>
 #include <string.h>
 #include <sys/uio.h>
@@ -89,6 +90,29 @@ int FsCreateTempDir(const char *dir, char **path)
     if (*path == NULL) {
         return -1;
     }
+    return 0;
+}
+
+/* Wrapper around remove(), compatible with ntfw. */
+static int dirRemoveFn(const char *path,
+                       const struct stat *sbuf,
+                       int type,
+                       struct FTW *ftwb)
+{
+    (void)sbuf;
+    (void)type;
+    (void)ftwb;
+    return remove(path);
+}
+
+int FsRemoveTempDir(char *path)
+{
+    int rv;
+    rv = nftw(path, dirRemoveFn, 10, FTW_DEPTH | FTW_MOUNT | FTW_PHYS);
+    if (rv != 0) {
+        return -1;
+    }
+    free(path);
     return 0;
 }
 

--- a/tools/benchmark/fs.c
+++ b/tools/benchmark/fs.c
@@ -6,7 +6,7 @@
 #include <sys/uio.h>
 #include <unistd.h>
 
-#include "disk_fs.h"
+#include "fs.h"
 
 /* Minimum physical block size for direct I/O that we expect to detect. */
 #define MIN_BLOCK_SIZE 512
@@ -23,7 +23,7 @@ static char *makeTempFileTemplate(const char *dir)
     return path;
 }
 
-int DiskFsCreateTempFile(const char *dir, size_t size, char **path, int *fd)
+int FsCreateTempFile(const char *dir, size_t size, char **path, int *fd)
 {
     int dirfd;
     int flags = O_WRONLY | O_CREAT | O_EXCL;
@@ -59,7 +59,7 @@ int DiskFsCreateTempFile(const char *dir, size_t size, char **path, int *fd)
     return 0;
 }
 
-int DiskFsRemoveTempFile(char *path, int fd)
+int FsRemoveTempFile(char *path, int fd)
 {
     int rv;
 
@@ -90,13 +90,13 @@ static int detectSuitableBlockSizesForDirectIO(const char *dir,
     size_t size;
     ssize_t rv;
 
-    rv = DiskFsCreateTempFile(dir, MAX_BLOCK_SIZE, &path, &fd);
+    rv = FsCreateTempFile(dir, MAX_BLOCK_SIZE, &path, &fd);
     if (rv != 0) {
         unlink(path);
         return -1;
     }
 
-    rv = DiskFsSetDirectIO(fd);
+    rv = FsSetDirectIO(fd);
     if (rv != 0) {
         return -1;
     }
@@ -122,7 +122,7 @@ static int detectSuitableBlockSizesForDirectIO(const char *dir,
         (*block_size)[*n_block_size - 1] = size;
     }
 
-    rv = DiskFsRemoveTempFile(path, fd);
+    rv = FsRemoveTempFile(path, fd);
     if (rv != 0) {
         return -1;
     }
@@ -130,7 +130,7 @@ static int detectSuitableBlockSizesForDirectIO(const char *dir,
     return 0;
 }
 
-int DiskFsCheckDirectIO(const char *dir, size_t buf)
+int FsCheckDirectIO(const char *dir, size_t buf)
 {
     size_t *block_size;
     unsigned n_block_size;
@@ -159,7 +159,7 @@ err:
     return -1;
 }
 
-int DiskFsSetDirectIO(int fd)
+int FsSetDirectIO(int fd)
 {
     int flags; /* Current fcntl flags */
     int rv;

--- a/tools/benchmark/fs.h
+++ b/tools/benchmark/fs.h
@@ -11,6 +11,9 @@ int FsCreateTempFile(const char *dir, size_t size, char **path, int *fd);
 /* Remove a temporary file. */
 int FsRemoveTempFile(char *path, int fd);
 
+/* Create a temporary directory under the given dir. */
+int FsCreateTempDir(const char *dir, char **path);
+
 /* Check if direct I/O is available when writing to files in the given dir using
  * the given buffer size. */
 int FsCheckDirectIO(const char *dir, size_t buf);

--- a/tools/benchmark/fs.h
+++ b/tools/benchmark/fs.h
@@ -1,21 +1,21 @@
 /* File-system utilities. */
 
-#ifndef DISK_FS_H_
-#define DISK_FS_H_
+#ifndef FS_H_
+#define FS_H_
 
 #include <stdlib.h>
 
 /* Create a temporary file of the given size. */
-int DiskFsCreateTempFile(const char *dir, size_t size, char **path, int *fd);
+int FsCreateTempFile(const char *dir, size_t size, char **path, int *fd);
 
 /* Remove a temporary file. */
-int DiskFsRemoveTempFile(char *path, int fd);
+int FsRemoveTempFile(char *path, int fd);
 
 /* Check if direct I/O is available when writing to files in the given dir using
  * the given buffer size. */
-int DiskFsCheckDirectIO(const char *dir, size_t buf);
+int FsCheckDirectIO(const char *dir, size_t buf);
 
 /* Set direct I/O on the given file descriptor. */
-int DiskFsSetDirectIO(int fd);
+int FsSetDirectIO(int fd);
 
-#endif /* DISK_FS_H_ */
+#endif /* FS_H_ */

--- a/tools/benchmark/fs.h
+++ b/tools/benchmark/fs.h
@@ -14,6 +14,9 @@ int FsRemoveTempFile(char *path, int fd);
 /* Create a temporary directory under the given dir. */
 int FsCreateTempDir(const char *dir, char **path);
 
+/* Recursively remove a temporary dir. */
+int FsRemoveTempDir(char *path);
+
 /* Check if direct I/O is available when writing to files in the given dir using
  * the given buffer size. */
 int FsCheckDirectIO(const char *dir, size_t buf);

--- a/tools/benchmark/main.c
+++ b/tools/benchmark/main.c
@@ -4,14 +4,20 @@
 
 #include "disk.h"
 #include "report.h"
+#include "submit.h"
 
-enum { BENCHMARK_DISK = 0 };
+enum {
+    BENCHMARK_DISK = 0,
+    BENCHMARK_SUBMIT,
+};
 
 static const char *doc =
     "benchmarks:\n"
-    " - disk: Sequential disk writes\n";
+    " - disk: Sequential disk writes\n"
+    " - submit: Sequential submission of entries\n";
 
-static const char *benchmarks[] = {[BENCHMARK_DISK] = "disk", NULL};
+static const char *benchmarks[] =
+    {[BENCHMARK_DISK] = "disk", [BENCHMARK_SUBMIT] = "submit", NULL};
 
 int benchmarkCode(const char *name)
 {
@@ -49,6 +55,9 @@ int main(int argc, char *argv[])
     switch (cmd) {
         case BENCHMARK_DISK:
             rv = DiskRun(argc - 1, &argv[1], &report);
+            break;
+        case BENCHMARK_SUBMIT:
+            rv = SubmitRun(argc - 1, &argv[1], &report);
             break;
         default:
             assert(0);

--- a/tools/benchmark/report.h
+++ b/tools/benchmark/report.h
@@ -3,6 +3,8 @@
 #ifndef REPORT_H_
 #define REPORT_H_
 
+#include <time.h>
+
 enum { METRIC_KIND_LATENCY = 0, METRIC_KIND_THROUGHPUT };
 
 struct metric
@@ -25,6 +27,14 @@ struct report
     struct benchmark **benchmarks;
     unsigned n_benchmarks;
 };
+
+/* Fill a metric object with a latency measurement, calculating the 50th
+ * percentile over the given samples. */
+void MetricFillLatency(struct metric *m, time_t *samples, unsigned n_samples);
+
+/* Fill a metric object with a throughput measurement, given the number of total
+ * operations and their total duration. */
+void MetricFillThroughput(struct metric *m, unsigned n_ops, time_t duration);
 
 /* Add a new metric to a benchmark. */
 struct metric *BenchmarkGrow(struct benchmark *b, int kind);

--- a/tools/benchmark/submit.c
+++ b/tools/benchmark/submit.c
@@ -1,0 +1,246 @@
+#include <assert.h>
+#include <stdlib.h>
+#include <string.h>
+#include <uv.h>
+
+#include "../../include/raft.h"
+#include "../../include/raft/uv.h"
+
+#include "fs.h"
+#include "submit.h"
+#include "submit_parse.h"
+
+static int fsmApply(struct raft_fsm *fsm,
+                    const struct raft_buffer *buf,
+                    void **result)
+{
+    (void)fsm;
+    (void)buf;
+    (void)result;
+    return 0;
+}
+
+struct server
+{
+    struct uv_loop_s *loop;
+    struct uv_timer_s timer;
+    struct raft_configuration configuration;
+    struct raft_uv_transport transport;
+    struct raft_io io;
+    struct raft_fsm fsm;
+    struct raft raft;
+    struct raft_buffer buf;
+    struct raft_apply req;
+    char *path;
+    unsigned i;
+    unsigned n;
+    time_t start;
+    time_t *latencies;
+};
+
+int serverInit(struct server *s,
+               struct submitOptions *opts,
+               struct uv_loop_s *loop)
+{
+    const char *address = "127.0.0.1:8080";
+    int rv;
+
+    s->loop = loop;
+    s->transport.version = 1;
+    s->transport.data = NULL;
+
+    s->i = 0;
+    s->n = opts->n;
+    s->latencies = malloc(opts->n * sizeof *s->latencies);
+    s->buf.len = opts->size;
+
+    rv = FsCreateTempDir(opts->dir, &s->path);
+    if (rv != 0) {
+        printf("failed to create temp dir\n");
+        return -1;
+    }
+
+    rv = raft_uv_tcp_init(&s->transport, loop);
+    if (rv != 0) {
+        printf("failed to init transport\n");
+        return -1;
+    }
+
+    rv = raft_uv_init(&s->io, loop, s->path, &s->transport);
+    if (rv != 0) {
+        printf("failed to init io\n");
+        return -1;
+    }
+
+    s->fsm.version = 1;
+    s->fsm.apply = fsmApply;
+    s->fsm.snapshot = NULL;
+    s->fsm.restore = NULL;
+
+    rv = raft_init(&s->raft, &s->io, &s->fsm, 1, address);
+    if (rv != 0) {
+        printf("failed to init raft\n");
+        return -1;
+    }
+
+    raft_configuration_init(&s->configuration);
+    rv = raft_configuration_add(&s->configuration, 1, address, RAFT_VOTER);
+    if (rv != 0) {
+        printf("failed to populate configuration\n");
+        return -1;
+    }
+    rv = raft_bootstrap(&s->raft, &s->configuration);
+    if (rv != 0) {
+        printf("failed to bootstrap\n");
+        return -1;
+    }
+    raft_configuration_close(&s->configuration);
+
+    /* Effectively disable snapshotting. */
+    raft_set_snapshot_threshold(&s->raft, 1024 * 1024);
+
+    rv = raft_start(&s->raft);
+    if (rv != 0) {
+        printf("failed to start raft '%s'\n", raft_strerror(rv));
+        return -1;
+    }
+
+    s->req.data = s;
+
+    uv_timer_init(s->loop, &s->timer);
+
+    return 0;
+}
+
+static int serverClose(struct server *s)
+{
+    int rv;
+
+    raft_uv_close(&s->io);
+    raft_uv_tcp_close(&s->transport);
+
+    rv = FsRemoveTempDir(s->path);
+    if (rv != 0) {
+        printf("failed to remove temp dir\n");
+        return -1;
+    }
+
+    free(s->latencies);
+
+    return 0;
+}
+
+static int submitEntry(struct server *s);
+
+static void raftCloseCb(struct raft *r)
+{
+    struct server *s = r->data;
+    uv_close((struct uv_handle_s *)&s->timer, NULL);
+}
+
+static void serverTimerCb(uv_timer_t *timer)
+{
+    struct server *s = timer->data;
+    s->raft.data = s;
+    raft_close(&s->raft, raftCloseCb);
+}
+
+static void submitEntryCb(struct raft_apply *req, int status, void *result)
+{
+    struct server *s = req->data;
+    int rv;
+
+    (void)result;
+
+    if (status != 0) {
+        printf("submission cb failed\n");
+        exit(1);
+    }
+
+    s->latencies[s->i] = (time_t)uv_hrtime() - s->start;
+
+    s->i++;
+    if (s->i == s->n) {
+        s->timer.data = s;
+        /* Run raft_close in the next loop iteration, to avoid calling it from a
+         * this commit callback, which triggers a bug in raft. */
+        uv_timer_start(&s->timer, serverTimerCb, 125, 0);
+        return;
+    }
+
+    rv = submitEntry(s);
+    if (rv != 0) {
+        printf("submission failed\n");
+        exit(1);
+    }
+}
+
+static int submitEntry(struct server *s)
+{
+    int rv;
+    s->start = (time_t)uv_hrtime();
+    const struct raft_buffer *bufs = &s->buf;
+
+    s->buf.base = raft_malloc(s->buf.len);
+    assert(s->buf.base != NULL);
+
+    rv = raft_apply(&s->raft, &s->req, bufs, 1, submitEntryCb);
+    if (rv != 0) {
+        return -1;
+    }
+
+    return 0;
+}
+
+int SubmitRun(int argc, char *argv[], struct report *report)
+{
+    struct submitOptions opts;
+    struct uv_loop_s loop;
+    struct server server;
+    struct metric *m;
+    struct benchmark *benchmark;
+    char *name;
+    int rv;
+
+    SubmitParse(argc, argv, &opts);
+
+    rv = uv_loop_init(&loop);
+    if (rv != 0) {
+        printf("failed to init loop\n");
+        return -1;
+    }
+
+    rv = serverInit(&server, &opts, &loop);
+    if (rv != 0) {
+        printf("failed to init server\n");
+        return -1;
+    }
+
+    rv = submitEntry(&server);
+    if (rv != 0) {
+        printf("failed to submit entry\n");
+        return -1;
+    }
+
+    rv = uv_run(&loop, UV_RUN_DEFAULT);
+    if (rv != 0) {
+        printf("failed to run loop\n");
+        return -1;
+    }
+
+    uv_loop_close(&loop);
+
+    name = malloc(strlen("submit") + 1);
+    strcpy(name, "submit");
+    benchmark = ReportGrow(report, name);
+    m = BenchmarkGrow(benchmark, METRIC_KIND_LATENCY);
+    MetricFillLatency(m, server.latencies, server.n);
+
+    rv = serverClose(&server);
+    if (rv != 0) {
+        printf("failed to cleanup\n");
+        return -1;
+    }
+
+    return 0;
+}

--- a/tools/benchmark/submit.h
+++ b/tools/benchmark/submit.h
@@ -1,0 +1,11 @@
+/* Run the submit benchmark. */
+
+#ifndef SUBMIT_H_
+#define SUBMIT_H_
+
+#include "report.h"
+
+/* Run the submit subcommand. */
+int SubmitRun(int argc, char *argv[], struct report *report);
+
+#endif /* SUBMIT_H_ */

--- a/tools/benchmark/submit_options.h
+++ b/tools/benchmark/submit_options.h
@@ -1,0 +1,16 @@
+/* Options for the submit benchmark. */
+
+#ifndef SUBMIT_OPTIONS_H_
+#define SUBMIT_OPTIONS_H_
+
+#include <stddef.h>
+
+/* Options for the submit benchmark */
+struct submitOptions
+{
+    char *dir;   /* Directory to use for creating temporary files */
+    size_t size; /* Size of each submitted entry */
+    unsigned n;  /* Number of submissions */
+};
+
+#endif /* SUBMIT_ARGS_H_ */

--- a/tools/benchmark/submit_parse.c
+++ b/tools/benchmark/submit_parse.c
@@ -1,0 +1,76 @@
+#include <argp.h>
+#include <assert.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "submit.h"
+#include "submit_parse.h"
+
+#define MEGABYTE (1024 * 1024)
+
+static char doc[] = "Benchmark sequential submit requests\n";
+
+/* Order of fields: {NAME, KEY, ARG, FLAGS, DOC, GROUP}.*/
+static struct argp_option options[] = {
+    {"dir", 'd', "DIR", 0, "Directory to use for temp files (default '.')", 0},
+    {"size", 's', "S", 0, "Size of each submitted entry (default 4k)", 0},
+    {"n", 'n', "N", 0, "Total number of entries to submit (default 2048)", 0},
+    {0}};
+
+static error_t argpParser(int key, char *arg, struct argp_state *state);
+
+static struct argp argp = {
+    .options = options,
+    .parser = argpParser,
+    .doc = doc,
+};
+
+static error_t argpParser(int key, char *arg, struct argp_state *state)
+{
+    struct submitOptions *opts = state->input;
+
+    switch (key) {
+        case 'd':
+            opts->dir = arg;
+            break;
+        case 's':
+            opts->size = (unsigned)atoi(arg);
+            break;
+        case 'n':
+            opts->n = (unsigned)atoi(arg);
+            break;
+        default:
+            return ARGP_ERR_UNKNOWN;
+    }
+
+    return 0;
+}
+
+static void optionsInit(struct submitOptions *opts)
+{
+    opts->dir = ".";
+    opts->size = 4096;
+    opts->n = 2048;
+}
+
+static void optionsCheck(struct submitOptions *opts)
+{
+    if (opts->size == 0 || (opts->size % 2048) != 0) {
+        printf("Invalid buffer entry size %zu\n", opts->size);
+        exit(1);
+    }
+    if (opts->n == 0) {
+        printf("Invalid number of submissions %u\n", opts->n);
+        exit(1);
+    }
+}
+
+void SubmitParse(int argc, char *argv[], struct submitOptions *opts)
+{
+    optionsInit(opts);
+
+    argv[0] = "benchmark/run submit";
+    argp_parse(&argp, argc, argv, 0, 0, opts);
+
+    optionsCheck(opts);
+}

--- a/tools/benchmark/submit_parse.h
+++ b/tools/benchmark/submit_parse.h
@@ -1,0 +1,11 @@
+/* Parse command line arguments for the submit benchmark. */
+
+#ifndef SUBMIT_ARGS_H_
+#define SUBMIT_ARGS_H_
+
+#include "submit_options.h"
+
+/* Parse the given command line arguments. */
+void SubmitParse(int argc, char *argv[], struct submitOptions *opts);
+
+#endif /* SUBMIT_ARGS_H_ */


### PR DESCRIPTION
This adds a new `submit` command to `raft-benchmark`, for benchmarking sequential append operations of new entries to the log.