### PR TITLE
[benchmark] disk: Ensure that fsync happens after write in io_uring

### DIFF
--- a/tools/benchmark/disk_uring.c
+++ b/tools/benchmark/disk_uring.c
@@ -166,7 +166,7 @@ static int writeWithUring(struct iovec *iov, unsigned i)
 
     /* Fill in the parameters required for the read or write operation */
     sqe->opcode = IORING_OP_WRITE_FIXED;
-    sqe->flags = IOSQE_FIXED_FILE;
+    sqe->flags = IOSQE_FIXED_FILE | IOSQE_IO_LINK;
     sqe->fd = 0;
     sqe->addr = (unsigned long)iov->iov_base;
     sqe->len = (unsigned)iov->iov_len;


### PR DESCRIPTION
This links the write operation to the fsync operation, so that the latter won't be started until the former has completed.