### PR TITLE
Use histograms for tracking latency in benchmarks

### DIFF
--- a/tools/benchmark/disk_kaio.c
+++ b/tools/benchmark/disk_kaio.c
@@ -7,7 +7,7 @@
 #include <sys/syscall.h>
 #include <unistd.h>
 
-#include "disk_uring.h"
+#include "disk_kaio.h"
 #include "timer.h"
 
 int io_setup(unsigned nr_events, aio_context_t *ctx_idp)
@@ -75,7 +75,10 @@ static int writeWithKaio(int fd, struct iovec *iov, unsigned i)
     return 0;
 }
 
-int DiskWriteUsingKaio(int fd, struct iovec *iov, unsigned n, time_t *latencies)
+int DiskWriteUsingKaio(int fd,
+                       struct iovec *iov,
+                       unsigned n,
+                       struct histogram *histogram)
 {
     struct timer timer;
     unsigned i;
@@ -95,7 +98,7 @@ int DiskWriteUsingKaio(int fd, struct iovec *iov, unsigned n, time_t *latencies)
         if (rv != 0) {
             return -1;
         }
-        latencies[i] = TimerStop(&timer);
+        HistogramCount(histogram, TimerStop(&timer));
     }
 
     rv = io_destroy(ctx);

--- a/tools/benchmark/disk_kaio.h
+++ b/tools/benchmark/disk_kaio.h
@@ -6,9 +6,11 @@
 #include <stddef.h>
 #include <sys/uio.h>
 
+#include "report.h"
+
 int DiskWriteUsingKaio(int fd,
                        struct iovec *iov,
                        unsigned n,
-                       time_t *latencies);
+                       struct histogram *histogram);
 
 #endif /* DISK_URING_H_ */

--- a/tools/benchmark/disk_pwrite.c
+++ b/tools/benchmark/disk_pwrite.c
@@ -21,7 +21,7 @@ static int writeWithPwrite(int fd, struct iovec *iov, unsigned i)
 int DiskWriteUsingPwrite(int fd,
                          struct iovec *iov,
                          unsigned n,
-                         time_t *latencies)
+                         struct histogram *histogram)
 {
     struct timer timer;
     unsigned i;
@@ -33,7 +33,7 @@ int DiskWriteUsingPwrite(int fd,
         if (rv != 0) {
             return -1;
         }
-        latencies[i] = TimerStop(&timer);
+        HistogramCount(histogram, TimerStop(&timer));
     }
 
     return 0;

--- a/tools/benchmark/disk_pwrite.h
+++ b/tools/benchmark/disk_pwrite.h
@@ -6,9 +6,11 @@
 #include <stddef.h>
 #include <sys/uio.h>
 
+#include "report.h"
+
 int DiskWriteUsingPwrite(int fd,
                          struct iovec *iov,
                          unsigned n,
-                         time_t *latencies);
+                         struct histogram *histogram);
 
 #endif /* DISK_PWRITE_H_ */

--- a/tools/benchmark/disk_uring.c
+++ b/tools/benchmark/disk_uring.c
@@ -256,7 +256,7 @@ static int writeWithUring(struct iovec *iov, unsigned i)
 int DiskWriteUsingUring(int fd,
                         struct iovec *iov,
                         unsigned n,
-                        time_t *latencies)
+                        struct histogram *histogram)
 {
     struct timer timer;
     unsigned i;
@@ -273,7 +273,7 @@ int DiskWriteUsingUring(int fd,
         if (rv != 0) {
             return -1;
         }
-        latencies[i] = TimerStop(&timer);
+        HistogramCount(histogram, TimerStop(&timer));
     }
 
     rv = _io_uring_register(_ring_fd, IORING_UNREGISTER_FILES, NULL, 0);

--- a/tools/benchmark/disk_uring.h
+++ b/tools/benchmark/disk_uring.h
@@ -6,9 +6,11 @@
 #include <stddef.h>
 #include <sys/uio.h>
 
+#include "report.h"
+
 int DiskWriteUsingUring(int fd,
                         struct iovec *iov,
                         unsigned n,
-                        time_t *latencies);
+                        struct histogram *histogram);
 
 #endif /* DISK_URING_H_ */

--- a/tools/benchmark/report.c
+++ b/tools/benchmark/report.c
@@ -77,25 +77,6 @@ static void metricPrint(struct metric *m)
     printf("    }");
 }
 
-static int compareLatencies(const void *a, const void *b)
-{
-    const time_t *ta = (const time_t *)a;
-    const time_t *tb = (const time_t *)b;
-
-    return (*ta > *tb) - (*ta < *tb);
-}
-
-void MetricFillLatency(struct metric *m, time_t *samples, unsigned n_samples)
-{
-    unsigned i;
-    qsort(samples, n_samples, sizeof *samples, compareLatencies);
-    i = (unsigned)((double)(n_samples)*PERCENTILE);
-
-    m->value = (double)samples[i];
-    m->lower_bound = (double)samples[0];
-    m->upper_bound = (double)samples[n_samples - 1];
-}
-
 void MetricFillHistogram(struct metric *m, struct histogram *h)
 {
     unsigned counter = 0;

--- a/tools/benchmark/report.c
+++ b/tools/benchmark/report.c
@@ -4,6 +4,42 @@
 
 #include "report.h"
 
+void HistogramInit(struct histogram *h,
+                   unsigned n,
+                   unsigned long first,
+                   unsigned gap)
+{
+    unsigned i;
+    assert(n >= 2);
+    h->n = n;
+    h->buckets = malloc(h->n * sizeof *h->buckets);
+    for (i = 0; i < n; i++) {
+        h->buckets[i] = 0;
+    }
+    assert(h->buckets != NULL);
+    h->first = first;
+    h->gap = gap;
+}
+
+void HistogramClose(struct histogram *h)
+{
+    free(h->buckets);
+}
+
+void HistogramCount(struct histogram *h, unsigned long value)
+{
+    unsigned i;
+    if (value <= h->first) {
+        i = 0;
+    } else {
+        i = (unsigned)(value - h->first) / h->gap;
+        if (i >= h->n) {
+            i = h->n - 1;
+        }
+    }
+    h->buckets[i]++;
+}
+
 /* Use the 0.50 percentile for reports. See:
  *
  * https://www.elastic.co/blog/averages-can-dangerous-use-percentile
@@ -60,7 +96,40 @@ void MetricFillLatency(struct metric *m, time_t *samples, unsigned n_samples)
     m->upper_bound = (double)samples[n_samples - 1];
 }
 
-void MetricFillThroughput(struct metric *m, unsigned n_ops, time_t duration)
+void MetricFillHistogram(struct metric *m, struct histogram *h)
+{
+    unsigned counter = 0;
+    unsigned median;
+    unsigned lower = 0;
+    unsigned upper = 0;
+    unsigned i;
+
+    for (i = 0; i < h->n; i++) {
+        counter += h->buckets[i];
+        if (lower == 0 && h->buckets[i] > 0) {
+            lower = i;
+        }
+        if (upper == 0 && h->buckets[h->n - 1 - i] > 0) {
+            upper = h->n - 1 - i;
+        }
+    }
+    median = counter / 2;
+    counter = 0;
+    for (i = 0; i <= h->n; i++) {
+        counter += h->buckets[i];
+        if (counter >= median) {
+            break;
+        }
+    }
+
+    m->value = (double)(h->first + (unsigned long)(i * h->gap));
+    m->lower_bound = (double)(h->first + (unsigned long)(lower * h->gap));
+    m->upper_bound = (double)(h->first + (unsigned long)(upper * h->gap));
+}
+
+void MetricFillThroughput(struct metric *m,
+                          unsigned n_ops,
+                          unsigned long duration)
 {
     double seconds = (double)duration / (1024 * 1024 * 1024);
     m->value = (double)n_ops / seconds;

--- a/tools/benchmark/report.h
+++ b/tools/benchmark/report.h
@@ -7,6 +7,14 @@
 
 enum { METRIC_KIND_LATENCY = 0, METRIC_KIND_THROUGHPUT };
 
+struct histogram
+{
+    unsigned *buckets;        /* buckets */
+    unsigned n;               /* number of buckets */
+    unsigned long long first; /* value of the first bucket */
+    unsigned gap;             /* gap between subsequent buckets */
+};
+
 struct metric
 {
     int kind;
@@ -28,13 +36,30 @@ struct report
     unsigned n_benchmarks;
 };
 
+/* Initialize a histogram object. */
+void HistogramInit(struct histogram *h,
+                   unsigned n,
+                   unsigned long first,
+                   unsigned gap);
+
+void HistogramClose(struct histogram *h);
+
+/* Update the counter of the bucket associated with the given value. */
+void HistogramCount(struct histogram *h, unsigned long value);
+
 /* Fill a metric object with a latency measurement, calculating the 50th
  * percentile over the given samples. */
 void MetricFillLatency(struct metric *m, time_t *samples, unsigned n_samples);
 
+/* Fill a metric object with a histogram-based measurement, calculating the 50th
+ * percentile over the buckets. */
+void MetricFillHistogram(struct metric *m, struct histogram *h);
+
 /* Fill a metric object with a throughput measurement, given the number of total
  * operations and their total duration. */
-void MetricFillThroughput(struct metric *m, unsigned n_ops, time_t duration);
+void MetricFillThroughput(struct metric *m,
+                          unsigned n_ops,
+                          unsigned long duration);
 
 /* Add a new metric to a benchmark. */
 struct metric *BenchmarkGrow(struct benchmark *b, int kind);

--- a/tools/benchmark/report.h
+++ b/tools/benchmark/report.h
@@ -47,10 +47,6 @@ void HistogramClose(struct histogram *h);
 /* Update the counter of the bucket associated with the given value. */
 void HistogramCount(struct histogram *h, unsigned long value);
 
-/* Fill a metric object with a latency measurement, calculating the 50th
- * percentile over the given samples. */
-void MetricFillLatency(struct metric *m, time_t *samples, unsigned n_samples);
-
 /* Fill a metric object with a histogram-based measurement, calculating the 50th
  * percentile over the buckets. */
 void MetricFillHistogram(struct metric *m, struct histogram *h);

--- a/tools/benchmark/timer.c
+++ b/tools/benchmark/timer.c
@@ -16,7 +16,7 @@ void TimerStart(struct timer *timer)
     timerNow(&timer->start);
 }
 
-time_t TimerStop(struct timer *timer)
+unsigned long TimerStop(struct timer *timer)
 {
     struct timespec now;
     time_t nsecs;
@@ -28,5 +28,5 @@ time_t TimerStop(struct timer *timer)
                 timer->start.tv_nsec + now.tv_nsec;
     }
 
-    return nsecs;
+    return (unsigned long)nsecs;
 }

--- a/tools/benchmark/timer.h
+++ b/tools/benchmark/timer.h
@@ -15,6 +15,6 @@ void TimerStart(struct timer *timer);
 
 /* Calculate how much time has elapsed since the timer started, in
  * nanosecods. */
-time_t TimerStop(struct timer *timer);
+unsigned long TimerStop(struct timer *timer);
 
 #endif /* TIMER_H_ */


### PR DESCRIPTION
Use histograms instead of arrays of exact latency measurements. That allows to have benchmarks with a longer time span, without any significant loss in accuracy.