### PR TITLE
benchmark: Use debugfs for tracing kernel activity

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -262,6 +262,7 @@ tools_raft_benchmark_SOURCES = \
   tools/benchmark/report.c \
   tools/benchmark/submit_parse.c \
   tools/benchmark/submit.c \
+  tools/benchmark/tracing.c \
   tools/benchmark/timer.c
 tools_raft_benchmark_LDFLAGS =
 tools_raft_benchmark_LDADD = libraft.la $(UV_LIBS)

--- a/tools/benchmark/disk.c
+++ b/tools/benchmark/disk.c
@@ -54,6 +54,7 @@ static void reportThroughput(struct benchmark *benchmark,
 
 /* Benchmark sequential write performance. */
 static int writeFile(struct diskOptions *opts,
+                     struct tracing *tracing,
                      bool raw,
                      struct benchmark *benchmark)
 {
@@ -91,6 +92,11 @@ static int writeFile(struct diskOptions *opts,
         }
     }
 
+    rv = TracingStart(tracing);
+    if (rv != 0) {
+        return rv;
+    }
+
     allocBuffer(&iov, opts->buf);
 
     HistogramInit(&histogram, BUCKETS, RESOLUTION, RESOLUTION);
@@ -117,6 +123,11 @@ static int writeFile(struct diskOptions *opts,
 
     if (rv != 0) {
         return -1;
+    }
+
+    rv = TracingStop(tracing);
+    if (rv != 0) {
+        return rv;
     }
 
     reportLatency(benchmark, &histogram);
@@ -176,7 +187,7 @@ int DiskRun(int argc, char *argv[], struct report *report)
 
         benchmark = ReportGrow(report, name);
 
-        rv = writeFile(opts, raw, benchmark);
+        rv = writeFile(opts, &matrix.tracing, raw, benchmark);
         if (rv != 0) {
             goto err;
         }

--- a/tools/benchmark/disk_parse.c
+++ b/tools/benchmark/disk_parse.c
@@ -130,7 +130,7 @@ static void optionsCheck(struct diskOptions *opts)
         printf("Invalid buffer size %zu\n", opts->buf);
         exit(1);
     }
-    if (opts->size == 0 || opts->size % MEGABYTE != 0) {
+    if (opts->size == 0 || opts->size % 4096 != 0) {
         printf("Invalid file size %u\n", opts->size);
         exit(1);
     }

--- a/tools/benchmark/disk_parse.c
+++ b/tools/benchmark/disk_parse.c
@@ -1,5 +1,6 @@
 #include <argp.h>
 #include <assert.h>
+#include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -19,6 +20,7 @@ static struct argp_option options[] = {
     {"size", 's', "S", 0, "Size of the file to write (default 8M)", 0},
     {"engine", 'e', "ENGINE", 0, "I/O engine to use: pwrite, kaio or uring", 0},
     {"mode", 'm', "MODE", 0, "I/O mode: buffer or direct", 0},
+    {"tracing", 't', "TRACING", 0, "Enable tracing using debugfs", 0},
     {0}};
 
 static error_t argpParser(int key, char *arg, struct argp_state *state);
@@ -60,6 +62,7 @@ static error_t argpParser(int key, char *arg, struct argp_state *state)
     unsigned i;
     unsigned j;
     unsigned k;
+    bool expanded = false;
 
     /* All our flags require and argument. So if there's no argument, this is
      * not a supported flag. */
@@ -73,11 +76,6 @@ static error_t argpParser(int key, char *arg, struct argp_state *state)
             n_tokens++;
     }
 
-    /* Multiply the matrix by the number of tokens. */
-    if (n_tokens > 1) {
-        expandMatrix(matrix, n_tokens);
-    }
-
     k = 0;
     for (i = 0; i < n_tokens; i++) {
         if (i == 0) {
@@ -86,6 +84,18 @@ static error_t argpParser(int key, char *arg, struct argp_state *state)
             token = strtok(NULL, ",");
         }
         assert(token != NULL);
+
+        switch (key) {
+            case 't':
+                TracingAdd(&matrix->tracing, token);
+                continue;
+        }
+
+        /* Multiply the matrix by the number of tokens. */
+        if (!expanded && n_tokens > 1) {
+            expandMatrix(matrix, n_tokens);
+            expanded = true;
+        }
 
         for (j = 0; j < n_opts; j++) {
             opts = &matrix->opts[k];
@@ -153,6 +163,7 @@ void DiskParse(int argc, char *argv[], struct diskMatrix *matrix)
     matrix->n_opts = 1;
 
     optionsInit(&matrix->opts[0]);
+    TracingInit(&matrix->tracing);
 
     argv[0] = "benchmark/run disk";
     argp_parse(&argp, argc, argv, 0, 0, matrix);

--- a/tools/benchmark/disk_parse.h
+++ b/tools/benchmark/disk_parse.h
@@ -4,12 +4,14 @@
 #define DISK_ARGS_H_
 
 #include "disk_options.h"
+#include "tracing.h"
 
 /* Array of all options combination to run. */
 struct diskMatrix
 {
     struct diskOptions *opts;
     unsigned n_opts;
+    struct tracing tracing;
 };
 
 /* Parse the given command line arguments. */

--- a/tools/benchmark/report.c
+++ b/tools/benchmark/report.c
@@ -94,7 +94,14 @@ void MetricFillHistogram(struct metric *m, struct histogram *h)
             upper = h->n - 1 - i;
         }
     }
-    median = counter / 2;
+
+    assert(counter >= 1);
+    if (counter == 1) {
+        median = 1;
+    } else {
+        median = counter / 2;
+    }
+
     counter = 0;
     for (i = 0; i <= h->n; i++) {
         counter += h->buckets[i];

--- a/tools/benchmark/tracing.c
+++ b/tools/benchmark/tracing.c
@@ -1,0 +1,69 @@
+#include <stdio.h>
+
+#include "tracing.h"
+
+#define PATH_TEMPLATE "/sys/kernel/debug/tracing/events/%s/enable"
+
+void TracingInit(struct tracing *t)
+{
+    t->n = 0;
+}
+
+void TracingAdd(struct tracing *t, char *system)
+{
+    t->systems[t->n] = system;
+    t->n++;
+}
+
+static int tracingWrite(const char *name, const char *op)
+{
+    char path[1024];
+    FILE *file;
+    sprintf(path, PATH_TEMPLATE, name);
+    file = fopen(path, "w");
+
+    if (file == NULL) {
+        perror("fopen debugfs");
+        return -1;
+    }
+    fprintf(file, "%s", op);
+    fclose(file);
+
+    return 0;
+}
+
+static int tracingEnable(const char *name)
+{
+    return tracingWrite(name, "1");
+}
+
+static int tracingDisable(const char *name)
+{
+    return tracingWrite(name, "0");
+}
+
+int TracingStart(struct tracing *t)
+{
+    unsigned i;
+    int rv;
+    for (i = 0; i < t->n; i++) {
+        rv = tracingEnable(t->systems[i]);
+        if (rv != 0) {
+            return rv;
+        }
+    }
+    return 0;
+}
+
+int TracingStop(struct tracing *t)
+{
+    unsigned i;
+    int rv;
+    for (i = 0; i < t->n; i++) {
+        rv = tracingDisable(t->systems[i]);
+        if (rv != 0) {
+            return rv;
+        }
+    }
+    return 0;
+}

--- a/tools/benchmark/tracing.h
+++ b/tools/benchmark/tracing.h
@@ -1,0 +1,22 @@
+/* Enable and disable tracing via debugfs. */
+
+#ifndef TRACING_H_
+#define TRACING_H_
+
+struct tracing
+{
+    char *systems[10]; /* Names of the sub-systems to trace. */
+    unsigned n;        /* Number of sub-systems to trace. */
+};
+
+void TracingInit(struct tracing *t);
+
+/* Add a new sub-system to trace. */
+void TracingAdd(struct tracing *t, char *system);
+
+/* Enable on tracing the given subsystem. */
+int TracingStart(struct tracing *t);
+
+int TracingStop(struct tracing *t);
+
+#endif /* TRACING_H_ */


### PR DESCRIPTION
Add a new `--tracing` flag to support tracing kernel activity via debugfs.