### PR TITLE
[benchmark] disk: Drop the --mode option, use only direct I/O

### DIFF
--- a/tools/benchmark/disk.c
+++ b/tools/benchmark/disk.c
@@ -85,11 +85,9 @@ static int writeFile(struct diskOptions *opts,
         return -1;
     }
 
-    if (opts->mode == DISK_MODE_DIRECT) {
-        rv = FsSetDirectIO(fd);
-        if (rv != 0) {
-            return -1;
-        }
+    rv = FsSetDirectIO(fd);
+    if (rv != 0) {
+        return -1;
     }
 
     rv = TracingStart(tracing);
@@ -171,17 +169,16 @@ int DiskRun(int argc, char *argv[], struct report *report)
         }
 
         assert(opts->buf != 0);
-        assert(opts->mode >= 0);
 
-        if (!raw && opts->mode == DISK_MODE_DIRECT) {
+        if (!raw) {
             rv = FsCheckDirectIO(opts->dir, opts->buf);
             if (rv != 0) {
                 goto err;
             }
         }
 
-        rv = asprintf(&name, "disk:%s:%s:%zu", DiskEngineName(opts->engine),
-                      DiskModeName(opts->mode), opts->buf);
+        rv = asprintf(&name, "disk:%s:%zu", DiskEngineName(opts->engine),
+                      opts->buf);
         assert(rv > 0);
         assert(name != NULL);
 

--- a/tools/benchmark/disk_options.c
+++ b/tools/benchmark/disk_options.c
@@ -7,9 +7,6 @@ static const char *engines[] = {[DISK_ENGINE_PWRITE] = "pwrite",
                                 [DISK_ENGINE_KAIO] = "kaio",
                                 NULL};
 
-static const char *modes[] =
-    {[DISK_MODE_BUFFER] = "buffer", [DISK_MODE_DIRECT] = "direct", NULL};
-
 int DiskEngineCode(const char *name)
 {
     int i = 0;
@@ -25,21 +22,4 @@ int DiskEngineCode(const char *name)
 const char *DiskEngineName(int code)
 {
     return engines[code];
-}
-
-int DiskModeCode(const char *mode)
-{
-    int i = 0;
-    while (modes[i] != NULL) {
-        if (strcmp(modes[i], mode) == 0) {
-            return i;
-        }
-        i++;
-    }
-    return -1;
-}
-
-const char *DiskModeName(int code)
-{
-    return modes[code];
 }

--- a/tools/benchmark/disk_options.h
+++ b/tools/benchmark/disk_options.h
@@ -8,9 +8,6 @@
 /* Disk I/O engines. */
 enum { DISK_ENGINE_PWRITE = 0, DISK_ENGINE_URING, DISK_ENGINE_KAIO };
 
-/* Disk I/O modes */
-enum { DISK_MODE_BUFFER = 0, DISK_MODE_DIRECT };
-
 /* Options for the disk benchmark */
 struct diskOptions
 {
@@ -18,7 +15,6 @@ struct diskOptions
     size_t buf;    /* Write buffer size */
     unsigned size; /* Size of the file to write, must be a multiple of buf */
     int engine;    /* OS write interface to use */
-    int mode;      /* Direct or buffered */
 };
 
 /* Translate a disk engine name to the associated code. Return -1 if unknown. */
@@ -29,8 +25,5 @@ const char *DiskEngineName(int code);
 
 /* Translate a disk mode name to the associated code. Return -1 if unknown. */
 int DiskModeCode(const char *mode);
-
-/* Translate a disk mode code to its associated name. */
-const char *DiskModeName(int code);
 
 #endif /* DISK_ARGS_H_ */

--- a/tools/benchmark/disk_parse.c
+++ b/tools/benchmark/disk_parse.c
@@ -19,7 +19,6 @@ static struct argp_option options[] = {
     {"buf", 'b', "BUF", 0, "Write buffer size (default 4096)", 0},
     {"size", 's', "S", 0, "Size of the file to write (default 8M)", 0},
     {"engine", 'e', "ENGINE", 0, "I/O engine to use: pwrite, kaio or uring", 0},
-    {"mode", 'm', "MODE", 0, "I/O mode: buffer or direct", 0},
     {"tracing", 't', "TRACING", 0, "Enable tracing using debugfs", 0},
     {0}};
 
@@ -113,9 +112,6 @@ static error_t argpParser(int key, char *arg, struct argp_state *state)
                 case 'e':
                     opts->engine = DiskEngineCode(token);
                     break;
-                case 'm':
-                    opts->mode = DiskModeCode(token);
-                    break;
                 default:
                     return ARGP_ERR_UNKNOWN;
             }
@@ -131,7 +127,6 @@ static void optionsInit(struct diskOptions *opts)
     opts->buf = 4096;
     opts->size = 8 * MEGABYTE;
     opts->engine = DISK_ENGINE_URING;
-    opts->mode = DISK_MODE_DIRECT;
 }
 
 static void optionsCheck(struct diskOptions *opts)
@@ -146,10 +141,6 @@ static void optionsCheck(struct diskOptions *opts)
     }
     if (opts->engine == -1) {
         printf("Invalid engine\n");
-        exit(1);
-    }
-    if (opts->mode == -1) {
-        printf("Invalid mode\n");
         exit(1);
     }
 }


### PR DESCRIPTION
No need to use buffered I/O, since it's slower in theory and also in practice.