### PR TITLE
[workflows] benchmark: Use cowsql/cowsql-ci instead of ad-hoc logic

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -75,6 +75,10 @@ jobs:
             fi
             sleep 60
         done
+        if [ "$STATUS" != "powered-on" ]; then
+           echo "Server still not ready: $STATUS"
+           exit 1
+        fi
         ADDR=$(curl -s -H "${HEADER}" ${API_URL}/${ID}/ | jq -r .publicIpAddresses[0])
         echo "address=$ADDR" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -12,31 +12,16 @@ on:
 jobs:
   github:
     name: On GitHub
-    strategy:
-      matrix:
-        ppa:
-          - main
-          - stable
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
-    - name: Setup dependencies
-      run: |
-        sudo add-apt-repository ppa:cowsql/${{ matrix.ppa }} -y
-        sudo apt-get update -qq
-        sudo apt-get install -qq -y libraft-tools
-    - uses: bencherdev/bencher@v0.3.6
-    - name: Run benchmark and send results to Bencher
+      with:
+        repository: cowsql/cowsql-ci
+    - name: Run checks
       env:
         BENCHER_API_TOKEN: ${{ secrets.BENCHER_API_TOKEN }}
-        BENCHER_BRANCH: ${{ matrix.ppa }}
-        BENCHER_TESTBED: github-ubuntu-22-04
-        BUFSIZES: 4096,8192,65536
       run: |
-        bencher run --project raft --testbed $BENCHER_TESTBED --branch $BENCHER_BRANCH \
-          "raft-benchmark disk -b $BUFSIZES"
-        bencher run --project raft --testbed $BENCHER_TESTBED --branch $BENCHER_BRANCH \
-          "raft-benchmark submit"
+        ./bin/check --testbed github
 
   bmc-deploy:
     name: On BMC - deploy
@@ -81,27 +66,29 @@ jobs:
         fi
         ADDR=$(curl -s -H "${HEADER}" ${API_URL}/${ID}/ | jq -r .publicIpAddresses[0])
         echo "address=$ADDR" >> $GITHUB_OUTPUT
+    - name: Update kernel
+      env:
+        SSH: "ssh -o StrictHostKeyChecking=no -i ~/.ssh/bmc ubuntu@${{ steps.wait.outputs.address}}"
+      run: |
+        mkdir -p ~/.ssh/
+        echo "${{secrets.BMC_SSH_KEY}}" > ~/.ssh/bmc
+        chmod 600 ~/.ssh/bmc
+        $SSH sudo apt-get install -y git
+        $SSH git clone --depth 1 https://github.com/cowsql/cowsql-ci.git ci
+        $SSH /home/ubuntu/ci/bin/install-kernel
+        $SSH sudo reboot || true
+        sleep 30
+        for i in $(seq 60); do
+          $SSH true 2>/dev/null && break
+          sleep 5
+        done
+        $SSH true
 
   bmc-run:
     name: On BMC - run
-    strategy:
-      max-parallel: 1
-      matrix:
-        ppa:
-          - main
-          - stable
-        driver:
-          - nvme
-          - null_blk
-        filesystem:
-          - ext4
-          - raw
     runs-on: ubuntu-22.04
     needs: bmc-deploy
     env:
-      PPA: ${{ matrix.ppa }}
-      DRIVER: ${{ matrix.driver }}
-      FILESYSTEM: ${{ matrix.filesystem }}
       SSH: "ssh -o StrictHostKeyChecking=no -i ~/.ssh/bmc ubuntu@${{ needs.bmc-deploy.outputs.address}}"
     steps:
     - name: Setup SSH key
@@ -109,85 +96,11 @@ jobs:
         mkdir -p ~/.ssh/
         echo "${{secrets.BMC_SSH_KEY}}" > ~/.ssh/bmc
         chmod 600 ~/.ssh/bmc
-    - name: Setup device
-      id: setup
-      run: |
-        case $DRIVER in
-          nvme)
-            device=/dev/nvme1n1
-            if $SSH sudo lsblk /dev/nvme1n1 -n -o MOUNTPOINTS | grep -q -e ^/$; then
-              device=/dev/nvme0n1
-            fi
-            $SSH sudo apt-get install nvme-cli
-            $SSH sudo nvme format --force --lbaf=1 "${device}"
-            $SSH sudo parted "${device}" --script mklabel gpt
-            $SSH sudo parted -a optimal "${device}" --script mkpart primary ext4 2048 15GB
-            $SSH sudo partprobe
-            partition=${device}p1
-            ;;
-          null_blk)
-            $SSH sudo modprobe null_blk bs=4096 memory_backed=1 gb=1
-            device=/dev/nullb0
-            partition=${device}
-            ;;
-          *)
-            echo "error: unknown block device driver $DRIVER"
-            exit 1
-            ;;
-        esac
-        target=/mnt
-        $SSH sudo add-apt-repository -y ppa:cowsql/$PPA
-        $SSH sudo apt-get update -qq
-        $SSH sudo apt-get install -qq -y libraft-tools xfsprogs
-        case $FILESYSTEM in
-          ext4)
-            $SSH sudo mkfs.ext4 -b 4096 -F "${partition}"
-            $SSH sudo tune2fs -O ^has_journal "${partition}"
-            $SSH sudo mount "${partition}" "${target}"
-            ;;
-          raw)
-            target=$device
-            ;;
-          *)
-            echo "error: unknown filesystem $FILESYSTEM"
-            exit 1
-            ;;
-        esac
-        $SSH sudo chown ubuntu $target
-        echo "target=$target" >> $GITHUB_OUTPUT
-    - uses: bencherdev/bencher@v0.3.6
-    - name: Run benchmark
+    - name: Run checks
       env:
         BENCHER_API_TOKEN: ${{ secrets.BENCHER_API_TOKEN }}
-        BENCHER_BRANCH: ${{ matrix.ppa }}
-        BENCHER_TESTBED: bmc-s1-c1-medium-${{ matrix.filesystem }}
-        BUFSIZES: 4096,8192,65536,262144
-        TARGET: ${{ steps.setup.outputs.target}}
       run: |
-        bencher run --project raft --testbed $BENCHER_TESTBED --branch $BENCHER_BRANCH \
-          "$SSH raft-benchmark disk -d $TARGET -b $BUFSIZES"
-        if [ "$FILESYSTEM" != "raw" ]; then
-          bencher run --project raft --testbed $BENCHER_TESTBED --branch $BENCHER_BRANCH \
-            "$SSH raft-benchmark submit -d $TARGET"
-        fi
-    - name: Cleanup
-      run: |
-        if [ $FILESYSTEM != raw ]; then
-          $SSH sudo umount ${{ steps.setup.outputs.target}}
-        fi
-        case $DRIVER in
-          nvme)
-            ;;
-          null_blk)
-            $SSH sudo modprobe -r null_blk
-            ;;
-          *)
-            echo "error: unknown block device driver $DRIVER"
-            exit 1
-            ;;
-        esac
-        $SSH sudo apt-get purge -y libraft-tools libraft2
-        $SSH sudo add-apt-repository -r -y ppa:cowsql/$PPA
+        $SSH "BENCHER_API_TOKEN=$BENCHER_API_TOKEN /home/ubuntu/ci/bin/check --testbed bmc"
 
   bmc-delete:
     name: On BMC - delete


### PR DESCRIPTION
Use the generic scripts from the `cowsql/cowsq-ci` branch instead of ad-hoc logic.