### PR TITLE
[benchmark] disk: Drop command line options matrix

### DIFF
--- a/tools/benchmark/disk.c
+++ b/tools/benchmark/disk.c
@@ -52,7 +52,7 @@ static void reportThroughput(struct benchmark *benchmark,
 
 /* Benchmark sequential write performance. */
 static int writeFile(struct diskOptions *opts,
-                     struct tracing *tracing,
+                     struct Tracing *tracing,
                      bool raw,
                      struct benchmark *benchmark)
 {

--- a/tools/benchmark/disk_options.h
+++ b/tools/benchmark/disk_options.h
@@ -4,6 +4,7 @@
 #define DISK_OPTIONS_H_
 
 #include <stddef.h>
+#include "tracing.h"
 
 /* Options for the disk benchmark */
 struct diskOptions
@@ -11,6 +12,7 @@ struct diskOptions
     char *dir;     /* Directory to use for creating temporary files */
     size_t buf;    /* Write buffer size */
     unsigned size; /* Size of the file to write, must be a multiple of buf */
+    struct Tracing tracing; /* Enable kernel tracing */
 };
 
 #endif /* DISK_ARGS_H_ */

--- a/tools/benchmark/disk_parse.h
+++ b/tools/benchmark/disk_parse.h
@@ -11,7 +11,7 @@ struct diskMatrix
 {
     struct diskOptions *opts;
     unsigned n_opts;
-    struct tracing tracing;
+    struct Tracing tracing;
 };
 
 /* Parse the given command line arguments. */

--- a/tools/benchmark/disk_parse.h
+++ b/tools/benchmark/disk_parse.h
@@ -4,17 +4,8 @@
 #define DISK_ARGS_H_
 
 #include "disk_options.h"
-#include "tracing.h"
-
-/* Array of all options combination to run. */
-struct diskMatrix
-{
-    struct diskOptions *opts;
-    unsigned n_opts;
-    struct Tracing tracing;
-};
 
 /* Parse the given command line arguments. */
-void DiskParse(int argc, char *argv[], struct diskMatrix *matrix);
+void DiskParse(int argc, char *argv[], struct diskOptions *opts);
 
 #endif /* DISK_ARGS_H_ */

--- a/tools/benchmark/disk_uring.h
+++ b/tools/benchmark/disk_uring.h
@@ -7,10 +7,12 @@
 #include <sys/uio.h>
 
 #include "report.h"
+#include "tracing.h"
 
 int DiskWriteUsingUring(int fd,
                         struct iovec *iov,
                         unsigned n,
+                        struct Tracing *tracing,
                         struct histogram *histogram);
 
 #endif /* DISK_URING_H_ */

--- a/tools/benchmark/tracing.c
+++ b/tools/benchmark/tracing.c
@@ -4,12 +4,12 @@
 
 #define PATH_TEMPLATE "/sys/kernel/debug/tracing/events/%s/enable"
 
-void TracingInit(struct tracing *t)
+void TracingInit(struct Tracing *t)
 {
     t->n = 0;
 }
 
-void TracingAdd(struct tracing *t, char *system)
+void TracingAdd(struct Tracing *t, char *system)
 {
     t->systems[t->n] = system;
     t->n++;
@@ -42,7 +42,7 @@ static int tracingDisable(const char *name)
     return tracingWrite(name, "0");
 }
 
-int TracingStart(struct tracing *t)
+int TracingStart(struct Tracing *t)
 {
     unsigned i;
     int rv;
@@ -55,7 +55,7 @@ int TracingStart(struct tracing *t)
     return 0;
 }
 
-int TracingStop(struct tracing *t)
+int TracingStop(struct Tracing *t)
 {
     unsigned i;
     int rv;

--- a/tools/benchmark/tracing.h
+++ b/tools/benchmark/tracing.h
@@ -3,20 +3,20 @@
 #ifndef TRACING_H_
 #define TRACING_H_
 
-struct tracing
+struct Tracing
 {
     char *systems[10]; /* Names of the sub-systems to trace. */
     unsigned n;        /* Number of sub-systems to trace. */
 };
 
-void TracingInit(struct tracing *t);
+void TracingInit(struct Tracing *t);
 
 /* Add a new sub-system to trace. */
-void TracingAdd(struct tracing *t, char *system);
+void TracingAdd(struct Tracing *t, char *system);
 
 /* Enable on tracing the given subsystem. */
-int TracingStart(struct tracing *t);
+int TracingStart(struct Tracing *t);
 
-int TracingStop(struct tracing *t);
+int TracingStop(struct Tracing *t);
 
 #endif /* TRACING_H_ */


### PR DESCRIPTION
This is no longer needed, since the cowsql-ci machinery takes care of expanding matrixes of test combinations.

Also, enable kernel tracing only during actual writes, to avoid spurious event entries (e.g. io_uring setup).