### PR TITLE
benchmark/disk: Adjust histogram buckets according to storage driver

### DIFF
--- a/tools/benchmark/disk.c
+++ b/tools/benchmark/disk.c
@@ -14,8 +14,17 @@
 #include "fs.h"
 #include "timer.h"
 
-#define RESOLUTION 100         /* buckets are 100 nanoseconds apart */
-#define BUCKETS 20 * 1000 * 10 /* buckets up to 20,000 microseconds */
+/* Histgram resolution when the underlying block driver is NVMe. */
+#define RESOLUTION_NVME 500        /* buckets are 0.5 microseconds apart */
+#define BUCKETS_NVME 20 * 1000 * 2 /* buckets up to 20,000 microseconds */
+
+/* Histgram resolution when the underlying block driver is nullb. */
+#define RESOLUTION_NULLB 50     /* buckets are 50 nanoseconds apart */
+#define BUCKETS_NULLB 1000 * 20 /* buckets up to 1,000 microseconds */
+
+/* Histgram resolution when the underlying block driver is unspecified. */
+#define RESOLUTION_GENERIC 1000   /* buckets are 1 microsecond apart */
+#define BUCKETS_GENERIC 20 * 1000 /* buckets up to 20,000 microseconds */
 
 /* Allocate a buffer of the given size. */
 static void allocBuffer(struct iovec *iov, size_t size)
@@ -50,6 +59,34 @@ static void reportThroughput(struct benchmark *benchmark,
     MetricFillThroughput(m, megabytes, duration);
 }
 
+/* Init the given histogram using a resolution and buckets count appropriate for
+ * the given driver type. */
+static void initHistogramForDriverType(struct histogram *histogram,
+                                       unsigned type)
+{
+    unsigned buckets;
+    unsigned resolution;
+
+    switch (type) {
+        case FS_DRIVER_NVME:
+            buckets = BUCKETS_NVME;
+            resolution = RESOLUTION_NVME;
+            break;
+        case FS_DRIVER_NULLB:
+            buckets = BUCKETS_NULLB;
+            resolution = RESOLUTION_NULLB;
+            break;
+        case FS_DRIVER_GENERIC:
+            buckets = BUCKETS_GENERIC;
+            resolution = RESOLUTION_GENERIC;
+            break;
+        default:
+            assert(0);
+            break;
+    }
+    HistogramInit(histogram, buckets, resolution, resolution);
+}
+
 /* Benchmark sequential write performance. */
 static int writeFile(struct diskOptions *opts, struct benchmark *benchmark)
 {
@@ -61,6 +98,7 @@ static int writeFile(struct diskOptions *opts, struct benchmark *benchmark)
     int fd;
     unsigned long duration;
     unsigned n = opts->size / (unsigned)opts->buf;
+    bool raw;
     int rv;
 
     rv = FsFileInfo(opts->dir, &info);
@@ -68,13 +106,17 @@ static int writeFile(struct diskOptions *opts, struct benchmark *benchmark)
         printf("file info '%s': %s\n", opts->dir, strerror(errno));
         return -1;
     }
+    raw = info.type == FS_TYPE_DEVICE;
 
     assert(opts->size % opts->buf == 0);
 
-    if (info.type == FS_TYPE_DEVICE) {
+    if (raw) {
         rv = FsOpenBlockDevice(opts->dir, &fd);
     } else {
         rv = FsCreateTempFile(opts->dir, n * opts->buf, &path, &fd);
+        if (rv == 0) {
+            rv = FsFileInfo(path, &info);
+        }
     }
     if (rv != 0) {
         return -1;
@@ -87,7 +129,7 @@ static int writeFile(struct diskOptions *opts, struct benchmark *benchmark)
 
     allocBuffer(&iov, opts->buf);
 
-    HistogramInit(&histogram, BUCKETS, RESOLUTION, RESOLUTION);
+    initHistogramForDriverType(&histogram, info.driver);
 
     TimerStart(&timer);
 
@@ -106,7 +148,7 @@ static int writeFile(struct diskOptions *opts, struct benchmark *benchmark)
 
     HistogramClose(&histogram);
 
-    if (info.type == FS_TYPE_REGULAR) {
+    if (!raw) {
         rv = FsRemoveTempFile(path, fd);
         if (rv != 0) {
             return -1;

--- a/tools/benchmark/disk.c
+++ b/tools/benchmark/disk.c
@@ -82,11 +82,6 @@ static int writeFile(struct diskOptions *opts,
         return -1;
     }
 
-    rv = FsSetDirectIO(fd);
-    if (rv != 0) {
-        return -1;
-    }
-
     allocBuffer(&iov, opts->buf);
 
     HistogramInit(&histogram, BUCKETS, RESOLUTION, RESOLUTION);

--- a/tools/benchmark/disk.c
+++ b/tools/benchmark/disk.c
@@ -58,7 +58,6 @@ static int writeFile(struct diskOptions *opts,
     struct timer timer;
     struct histogram histogram;
     struct iovec iov;
-    struct stat st;
     char *path;
     int fd;
     unsigned long duration;
@@ -66,12 +65,6 @@ static int writeFile(struct diskOptions *opts,
     int rv;
 
     assert(opts->size % opts->buf == 0);
-
-    rv = stat(opts->dir, &st);
-    if (rv != 0) {
-        printf("stat '%s': %s\n", opts->dir, strerror(errno));
-        return -1;
-    }
 
     if (raw) {
         rv = FsOpenBlockDevice(opts->dir, &fd);

--- a/tools/benchmark/disk.c
+++ b/tools/benchmark/disk.c
@@ -74,13 +74,6 @@ static int writeFile(struct diskOptions *opts, struct benchmark *benchmark)
         raw = true;
     }
 
-    if (!raw) {
-        rv = FsCheckDirectIO(opts->dir, opts->buf);
-        if (rv != 0) {
-            return -1;
-        }
-    }
-
     assert(opts->size % opts->buf == 0);
 
     if (raw) {
@@ -88,6 +81,11 @@ static int writeFile(struct diskOptions *opts, struct benchmark *benchmark)
     } else {
         rv = FsCreateTempFile(opts->dir, n * opts->buf, &path, &fd);
     }
+    if (rv != 0) {
+        return -1;
+    }
+
+    rv = FsCheckDirectIO(fd, opts->buf);
     if (rv != 0) {
         return -1;
     }

--- a/tools/benchmark/fs.c
+++ b/tools/benchmark/fs.c
@@ -128,20 +128,12 @@ int FsOpenBlockDevice(const char *dir, int *fd)
 
 /* Detect all suitable block size we can use to write to the underlying device
  * using direct I/O. */
-static int detectSuitableBlockSizesForDirectIO(const char *dir,
+static int detectSuitableBlockSizesForDirectIO(int fd,
                                                size_t **block_size,
                                                unsigned *n_block_size)
 {
-    char *path;
-    int fd;
     size_t size;
     ssize_t rv;
-
-    rv = FsCreateTempFile(dir, MAX_BLOCK_SIZE, &path, &fd);
-    if (rv != 0) {
-        unlink(path);
-        return -1;
-    }
 
     *block_size = NULL;
     *n_block_size = 0;
@@ -162,11 +154,6 @@ static int detectSuitableBlockSizesForDirectIO(const char *dir,
         *block_size = realloc(*block_size, *n_block_size * sizeof **block_size);
         assert(*block_size != NULL);
         (*block_size)[*n_block_size - 1] = size;
-    }
-
-    rv = FsRemoveTempFile(path, fd);
-    if (rv != 0) {
-        return -1;
     }
 
     return 0;
@@ -198,14 +185,14 @@ int FsFileExists(const char *dir, const char *name, bool *exists)
     return 0;
 }
 
-int FsCheckDirectIO(const char *dir, size_t buf)
+int FsCheckDirectIO(int fd, size_t buf)
 {
     size_t *block_size;
     unsigned n_block_size;
     unsigned i;
     int rv;
 
-    rv = detectSuitableBlockSizesForDirectIO(dir, &block_size, &n_block_size);
+    rv = detectSuitableBlockSizesForDirectIO(fd, &block_size, &n_block_size);
     if (rv != 0) {
         goto err;
     }

--- a/tools/benchmark/fs.h
+++ b/tools/benchmark/fs.h
@@ -12,9 +12,9 @@ enum {
 };
 
 enum {
-    FS_DRIVER_NVME,    /* NVMe driver */
-    FS_DRIVER_NULLB,   /* nullb driver */
-    FS_DRIVER_GENERIC, /* Unspecified underlying driver */
+    FS_DRIVER_NVME = 0, /* NVMe driver */
+    FS_DRIVER_NULLB,    /* nullb driver */
+    FS_DRIVER_GENERIC,  /* Unspecified underlying driver */
 };
 
 /* Hold information about a file. */

--- a/tools/benchmark/fs.h
+++ b/tools/benchmark/fs.h
@@ -6,6 +6,27 @@
 #include <stdbool.h>
 #include <stdlib.h>
 
+enum {
+    FS_TYPE_REGULAR, /* Regular file or directory */
+    FS_TYPE_DEVICE,  /* Block device */
+};
+
+enum {
+    FS_DRIVER_NVME,    /* NVMe driver */
+    FS_DRIVER_NULLB,   /* nullb driver */
+    FS_DRIVER_GENERIC, /* Unspecified underlying driver */
+};
+
+/* Hold information about a file. */
+struct FsFileInfo
+{
+    unsigned type;
+    unsigned driver;
+};
+
+/* Detect file information. */
+int FsFileInfo(const char *path, struct FsFileInfo *info);
+
 /* Create a temporary file of the given size. */
 int FsCreateTempFile(const char *dir, size_t size, char **path, int *fd);
 
@@ -27,8 +48,5 @@ int FsFileExists(const char *dir, const char *name, bool *exists);
 /* Check if direct I/O is possible when writing to the the given fd with the
  * given buffer size. */
 int FsCheckDirectIO(int fd, size_t buf);
-
-/* Set direct I/O on the given file descriptor. */
-int FsSetDirectIO(int fd);
 
 #endif /* FS_H_ */

--- a/tools/benchmark/fs.h
+++ b/tools/benchmark/fs.h
@@ -24,9 +24,9 @@ int FsOpenBlockDevice(const char *dir, int *fd);
 /* Check if a file exists in the given dir. */
 int FsFileExists(const char *dir, const char *name, bool *exists);
 
-/* Check if direct I/O is available when writing to files in the given dir using
- * the given buffer size. */
-int FsCheckDirectIO(const char *dir, size_t buf);
+/* Check if direct I/O is possible when writing to the the given fd with the
+ * given buffer size. */
+int FsCheckDirectIO(int fd, size_t buf);
 
 /* Set direct I/O on the given file descriptor. */
 int FsSetDirectIO(int fd);


### PR DESCRIPTION
Histogram resolution and buckets are now dynamically adjusted according to the underlying kernel storage driver (NVMe, nullb, etc), so timings can be a bit more accurate.