### PR TITLE
benchmark/disk: Poll io_uring completion queue

### DIFF
--- a/tools/benchmark/disk.c
+++ b/tools/benchmark/disk.c
@@ -133,7 +133,7 @@ static int writeFile(struct diskOptions *opts, struct benchmark *benchmark)
 
     TimerStart(&timer);
 
-    rv = DiskWriteUsingUring(fd, &iov, n, &opts->tracing, &histogram);
+    rv = DiskWriteUsingUring(fd, &iov, n, &info, &opts->tracing, &histogram);
 
     duration = TimerStop(&timer);
 

--- a/tools/benchmark/disk_uring.c
+++ b/tools/benchmark/disk_uring.c
@@ -220,12 +220,15 @@ retry:
     return 0;
 }
 
+#endif /* HAVE_LINUX_IO_URING_H */
+
 int DiskWriteUsingUring(int fd,
                         struct iovec *iov,
                         unsigned n,
                         struct Tracing *tracing,
                         struct histogram *histogram)
 {
+#if defined(HAVE_LINUX_IO_URING_H)
     struct timer timer;
     unsigned i;
     int rv;
@@ -269,16 +272,9 @@ int DiskWriteUsingUring(int fd,
     close(_ring_fd);
 
     return 0;
-}
 
 #else /* HAVE_LINUX_IO_URING_H */
 
-int DiskWriteUsingUring(int fd,
-                        struct iovec *iov,
-                        unsigned n,
-                        struct Tracing *tracing,
-                        struct histogram *histogram)
-{
     (void)fd;
     (void)iov;
     (void)n;
@@ -286,6 +282,6 @@ int DiskWriteUsingUring(int fd,
     (void)histogram;
     fprintf(stderr, "io_uring not available\n");
     return -1;
-}
 
 #endif /* HAVE_LINUX_IO_URING_H */
+}

--- a/tools/benchmark/disk_uring.h
+++ b/tools/benchmark/disk_uring.h
@@ -6,12 +6,14 @@
 #include <stddef.h>
 #include <sys/uio.h>
 
+#include "fs.h"
 #include "report.h"
 #include "tracing.h"
 
 int DiskWriteUsingUring(int fd,
                         struct iovec *iov,
                         unsigned n,
+                        struct FsFileInfo *info,
                         struct Tracing *tracing,
                         struct histogram *histogram);
 

--- a/tools/benchmark/tracing.h
+++ b/tools/benchmark/tracing.h
@@ -1,4 +1,4 @@
-/* Enable and disable tracing via debugfs. */
+/* Kernel tracing helpers. */
 
 #ifndef TRACING_H_
 #define TRACING_H_
@@ -7,6 +7,7 @@ struct Tracing
 {
     char *systems[10]; /* Names of the sub-systems to trace. */
     unsigned n;        /* Number of sub-systems to trace. */
+    unsigned switches; /* Number of context switches performed. */
 };
 
 void TracingInit(struct Tracing *t);


### PR DESCRIPTION
Instead of waiting for I/O completion using `io_uring_enter()` (which blocks and then resumes the thread), poll the completion queue directly. This results in slightly better performance.