### PR TITLE
test_snapshot: Receive AppendEntries while installing a snapshot

### DIFF
--- a/src/replication.h
+++ b/src/replication.h
@@ -26,7 +26,7 @@ int replicationTrigger(struct raft *r, raft_index index);
  *   response during the last heartbeat interval), then send a message only if
  *   haven't sent any during the last heartbeat interval.
  *
- * - If we are pipelining entries to the follower, then send any new entries
+ * - If we are pipelining entries to the follower, then send any new entries we
  *   haven't yet sent.
  *
  * If a message should be sent, the rules to decide what type of message to send


### PR DESCRIPTION
Add an explicit test for receiving AppendEntries requests while installing a
snapshot, making sure that those entries are properly ignored and their memory
released.
