### PR TITLE
replication: Replace if statement with assertion

### DIFF
--- a/src/log.h
+++ b/src/log.h
@@ -108,9 +108,10 @@ int logAppendConfiguration(struct raft_log *l,
                            const raft_term term,
                            const struct raft_configuration *configuration);
 
-/* Acquire an array of entries from the given index onwards. * The payload
- * memory referenced by the @buf attribute of the returned entries is guaranteed
- * to be valid until logRelease() is called. */
+/* Acquire an array of entries from the given index onwards.
+ *
+ * The payload memory referenced by the @buf attribute of the returned entries
+ * is guaranteed to be valid until logRelease() is called. */
 int logAcquire(struct raft_log *l,
                raft_index index,
                struct raft_entry *entries[],


### PR DESCRIPTION
The true branch of the if statement being removed can't be taken, because of the reason explained in the comment.

This code was indeed untested.
