### PR TITLE
benchmark/disk: Pre-write the benchmark file to allocate extents

### DIFF
--- a/tools/benchmark/disk.c
+++ b/tools/benchmark/disk.c
@@ -97,11 +97,6 @@ static int openFile(struct diskOptions *opts,
         return -1;
     }
 
-    rv = FsCheckDirectIO(*fd, opts->buf);
-    if (rv != 0) {
-        return -1;
-    }
-
     return 0;
 }
 

--- a/tools/benchmark/disk_uring.c
+++ b/tools/benchmark/disk_uring.c
@@ -238,12 +238,6 @@ int DiskWriteUsingUring(int fd,
         return -1;
     }
 
-    /* Perform a first write to trigger initialization and warm up caches. */
-    rv = writeWithUring(iov, 0);
-    if (rv != 0) {
-        return -1;
-    }
-
     rv = ProfilerStart(profiler);
     if (rv != 0) {
         return rv;

--- a/tools/benchmark/fs.h
+++ b/tools/benchmark/fs.h
@@ -45,8 +45,4 @@ int FsOpenBlockDevice(const char *dir, int *fd);
 /* Check if a file exists in the given dir. */
 int FsFileExists(const char *dir, const char *name, bool *exists);
 
-/* Check if direct I/O is possible when writing to the the given fd with the
- * given buffer size. */
-int FsCheckDirectIO(int fd, size_t buf);
-
 #endif /* FS_H_ */


### PR DESCRIPTION
We were effectively already pre-writing the file, by probing the possible direct I/O buffer sizes, however we were doing that only up to 1M.

This change now explicitly pre-writes the entire file.