### PR TITLE
benchmark/disk: Add more block/nvme command profiler checks

### DIFF
--- a/tools/benchmark/disk_uring.c
+++ b/tools/benchmark/disk_uring.c
@@ -238,6 +238,12 @@ int DiskWriteUsingUring(int fd,
         return -1;
     }
 
+    /* Perform a first write to trigger initialization and warm up caches. */
+    rv = writeWithUring(iov, 0);
+    if (rv != 0) {
+        return -1;
+    }
+
     rv = ProfilerStart(profiler);
     if (rv != 0) {
         return rv;

--- a/tools/benchmark/fs.h
+++ b/tools/benchmark/fs.h
@@ -22,6 +22,8 @@ struct FsFileInfo
 {
     unsigned type;
     unsigned driver;
+    unsigned block_dev_start; /* First sector of the underlying block device */
+    unsigned block_dev_end;   /* End sector of the underlying block device */
 };
 
 /* Detect file information. */

--- a/tools/benchmark/profiler.c
+++ b/tools/benchmark/profiler.c
@@ -448,6 +448,10 @@ static int processNvmeSetupCmd(struct ProfilerEventGroup *g,
 {
     struct ProfilerDataSource *data = &g->p->nvme;
     unsigned i = data->n_commands;
+    if (t->opcode != 0x01 /* Write opcode, from linux/nvme.h */) {
+        printf("unexpected nvme opecode 0x%x\n", t->opcode);
+        return -1;
+    }
     data->commands[i].id = t->cid;
     data->commands[i].start = s->time;
     data->n_commands++;

--- a/tools/benchmark/profiler.c
+++ b/tools/benchmark/profiler.c
@@ -95,6 +95,7 @@ struct blockBioQueue
     struct tracepoint tp;
     u32 dev;
     u64 sector;
+    u32 nr_sector;
 };
 
 struct blockRqComplete
@@ -295,10 +296,11 @@ static int profilerInitPerf(struct Profiler *p)
     return 0;
 }
 
-int ProfilerInit(struct Profiler *p)
+int ProfilerInit(struct Profiler *p, struct FsFileInfo *device)
 {
     int rv;
 
+    p->device = device;
     p->n_traces = 0;
     p->switches = 0;
 
@@ -447,11 +449,18 @@ static int processNvmeSetupCmd(struct ProfilerEventGroup *g,
                                struct nvmeSetupCmd *t)
 {
     struct ProfilerDataSource *data = &g->p->nvme;
+    struct FsFileInfo *device = g->p->device;
     unsigned i = data->n_commands;
+    u64 slba = *(u64 *)(t->cdw10);
     u16 control = *(u16 *)(t->cdw10 + 10);
 
+    /* Skip writes targeted to other partitions. */
+    if (slba < device->block_dev_start || slba >= device->block_dev_end) {
+        return 0;
+    }
+
     if (t->opcode != 0x01 /* Write opcode, from linux/nvme.h */) {
-        printf("unexpected nvme opecode 0x%x\n", t->opcode);
+        printf("unexpected nvme opcode 0x%x\n", t->opcode);
         return -1;
     }
 
@@ -472,6 +481,7 @@ static int processNvmeCompleteRq(struct ProfilerEventGroup *g,
 {
     struct ProfilerDataSource *data = &g->p->nvme;
     unsigned i;
+
     for (i = 0; i < data->n_commands; i++) {
         if (data->commands[i].id != (unsigned long long)t->cid) {
             continue;
@@ -479,7 +489,11 @@ static int processNvmeCompleteRq(struct ProfilerEventGroup *g,
         data->commands[i].duration = s->time - data->commands[i].start;
         return 0;
     }
-    return -1;
+
+    /* The setup for this completion was probably skipped. TODO: make sure of
+     * that. */
+
+    return 0;
 }
 
 static int processBlockBioQueue(struct ProfilerEventGroup *g,
@@ -487,11 +501,20 @@ static int processBlockBioQueue(struct ProfilerEventGroup *g,
                                 struct blockBioQueue *t)
 {
     struct ProfilerDataSource *data = &g->p->block;
+    struct FsFileInfo *device = g->p->device;
     unsigned i = data->n_commands;
+
+    /* Skip writes targeted to other partitions. */
+    if (t->sector < device->block_dev_start ||
+        t->sector >= device->block_dev_end) {
+        return 0;
+    }
+
     data->commands[i].id = t->sector;
     data->commands[i].start = s->time;
     data->commands[i].duration = 0;
     data->n_commands++;
+
     return 0;
 }
 
@@ -500,7 +523,15 @@ static int processBlockRqComplete(struct ProfilerEventGroup *g,
                                   struct blockRqComplete *t)
 {
     struct ProfilerDataSource *data = &g->p->block;
+    struct FsFileInfo *device = g->p->device;
     unsigned i;
+
+    /* Skip writes targeted to other partitions. */
+    if (t->sector < device->block_dev_start ||
+        t->sector >= device->block_dev_end) {
+        return 0;
+    }
+
     for (i = 0; i < data->n_commands; i++) {
         if (data->commands[i].id != t->sector) {
             continue;
@@ -520,7 +551,15 @@ static int processBlockBioComplete(struct ProfilerEventGroup *g,
                                    struct blockBioComplete *t)
 {
     struct ProfilerDataSource *data = &g->p->block;
+    struct FsFileInfo *device = g->p->device;
     unsigned i;
+
+    /* Skip writes targeted to other partitions. */
+    if (t->sector < device->block_dev_start ||
+        t->sector >= device->block_dev_end) {
+        return 0;
+    }
+
     for (i = 0; i < data->n_commands; i++) {
         if (data->commands[i].id != t->sector) {
             continue;

--- a/tools/benchmark/profiler.h
+++ b/tools/benchmark/profiler.h
@@ -3,6 +3,8 @@
 #ifndef PROFILER_H_
 #define PROFILER_H_
 
+#include "fs.h"
+
 struct Profiler;
 
 /* Group of per-CPU perf events. */
@@ -30,16 +32,17 @@ struct ProfilerDataSource
 
 struct Profiler
 {
-    const char *traces[10]; /* Names of the kernel sub-systems to trace. */
-    unsigned n_traces;      /* Number of sub-systems to trace. */
-    unsigned switches;      /* Number of context switches performed. */
+    struct FsFileInfo *device; /* Information about the underlying device. */
+    const char *traces[10];    /* Names of the kernel sub-systems to trace. */
+    unsigned n_traces;         /* Number of sub-systems to trace. */
+    unsigned switches;         /* Number of context switches performed. */
     struct ProfilerEventGroup *groups; /* Groups of per-CPU events.. */
     unsigned n_groups;
     struct ProfilerDataSource nvme;
     struct ProfilerDataSource block;
 };
 
-int ProfilerInit(struct Profiler *t);
+int ProfilerInit(struct Profiler *t, struct FsFileInfo *device);
 
 void ProfilerClose(struct Profiler *t);
 


### PR DESCRIPTION
Make the profiler smarter about the commands it processes, filtering out spurious commands that are actually triggered by the rest of the system, not by the benchmark.