### PR TITLE
benchmark/disk: Make kernel performance measuring optional

### DIFF
--- a/tools/benchmark/disk_options.h
+++ b/tools/benchmark/disk_options.h
@@ -13,6 +13,7 @@ struct diskOptions
     char *dir;     /* Directory to use for creating temporary files */
     size_t buf;    /* Write buffer size */
     unsigned size; /* Size of the file to write, must be a multiple of buf */
+    bool perf;     /* Turn on or off kernel performance measuring */
     const char *traces[8]; /* Kernel sub-systems to trace */
     unsigned n_traces;
 };

--- a/tools/benchmark/fs.c
+++ b/tools/benchmark/fs.c
@@ -105,7 +105,7 @@ int FsFileInfo(const char *path, struct FsFileInfo *info)
     unsigned dev_size;
     char block[1024];
     char link[1024];
-    char parent[1024];
+    char parent[8192]; /* TODO: suppress -Werror=format-overflow */
     const char *name;
     int rv;
 

--- a/tools/benchmark/profiler.c
+++ b/tools/benchmark/profiler.c
@@ -272,11 +272,6 @@ static int profilerInitPerf(struct Profiler *p)
     unsigned i;
     int rv;
 
-    if (getuid() != 0) {
-        p->n_groups = 0;
-        return 0;
-    }
-
     profilerInitDataSource(&p->nvme, NVME);
     profilerInitDataSource(&p->block, BLOCK);
 
@@ -296,19 +291,21 @@ static int profilerInitPerf(struct Profiler *p)
     return 0;
 }
 
-int ProfilerInit(struct Profiler *p, struct FsFileInfo *device)
+void ProfilerInit(struct Profiler *p, struct FsFileInfo *device)
 {
-    int rv;
-
     p->device = device;
     p->n_traces = 0;
+    p->n_groups = 0;
     p->switches = 0;
+}
 
+int ProfilerPerf(struct Profiler *p)
+{
+    int rv;
     rv = profilerInitPerf(p);
     if (rv != 0) {
         return rv;
     }
-
     return 0;
 }
 

--- a/tools/benchmark/profiler.h
+++ b/tools/benchmark/profiler.h
@@ -42,17 +42,20 @@ struct Profiler
     struct ProfilerDataSource block;
 };
 
-int ProfilerInit(struct Profiler *t, struct FsFileInfo *device);
+void ProfilerInit(struct Profiler *p, struct FsFileInfo *device);
 
-void ProfilerClose(struct Profiler *t);
+void ProfilerClose(struct Profiler *p);
+
+/* Turn on performance profiling. */
+int ProfilerPerf(struct Profiler *p);
 
 /* Trace the given kernel sub-system using tracefs. The output will be available
  * under /sys/kernel/tracing/trace. */
-void ProfilerTrace(struct Profiler *t, const char *system);
+void ProfilerTrace(struct Profiler *p, const char *system);
 
 /* Enable on profiler the given subsystem. */
-int ProfilerStart(struct Profiler *t);
+int ProfilerStart(struct Profiler *p);
 
-int ProfilerStop(struct Profiler *t);
+int ProfilerStop(struct Profiler *p);
 
 #endif /* PROFILER_H_ */


### PR DESCRIPTION
There is a bit of overhead that comes from using perf_event_open() to measure the performance of the various kernel sub-systems.

This feature is now off by default, and must be enabled using the new --perf command line option.
