### PR TITLE
benchmark/submit: Adjust command line arguments

### DIFF
--- a/tools/benchmark/submit.c
+++ b/tools/benchmark/submit.c
@@ -274,8 +274,10 @@ int SubmitRun(int argc, char *argv[], struct report *report)
 
     uv_loop_close(&loop);
 
-    name = malloc(strlen("submit") + 1);
-    strcpy(name, "submit");
+    rv = asprintf(&name, "submit:%zu", opts.buf);
+    assert(rv > 0);
+    assert(name != NULL);
+
     benchmark = ReportGrow(report, name);
     m = BenchmarkGrow(benchmark, METRIC_KIND_LATENCY);
     MetricFillHistogram(m, &server.histogram);

--- a/tools/benchmark/submit.c
+++ b/tools/benchmark/submit.c
@@ -34,7 +34,7 @@ struct server
     struct raft raft;
     struct raft_buffer buf;
     struct raft_apply req;
-    size_t size;
+    size_t entry;
     char *path;
     unsigned i;
     unsigned n;
@@ -54,8 +54,8 @@ int serverInit(struct server *s,
     s->transport.data = NULL;
 
     s->i = 0;
-    s->n = opts->n;
-    s->size = opts->size;
+    s->n = (unsigned)(opts->size / opts->buf);
+    s->entry = opts->buf;
     s->timer.data = s;
 
     HistogramInit(&s->histogram, BUCKETS, RESOLUTION, RESOLUTION);
@@ -221,7 +221,7 @@ static int submitEntry(struct server *s)
     s->start = (unsigned long)uv_hrtime();
     const struct raft_buffer *bufs = &s->buf;
 
-    s->buf.len = s->size - 8 /* CRC */ - 8 /* N entries */ - 16 /* header */;
+    s->buf.len = s->entry - 8 /* CRC */ - 8 /* N entries */ - 16 /* header */;
     if (s->i == 0) {
         s->buf.len -= 8; /* segment format */
     }

--- a/tools/benchmark/submit_options.h
+++ b/tools/benchmark/submit_options.h
@@ -8,9 +8,9 @@
 /* Options for the submit benchmark */
 struct submitOptions
 {
-    char *dir;   /* Directory to use for creating temporary files */
-    size_t size; /* Size of each submitted entry */
-    unsigned n;  /* Number of submissions */
+    char *dir;     /* Directory to use for creating temporary files */
+    size_t buf;    /* Buffer size of each raft entry to submit */
+    unsigned size; /* Total number of bytes to submit */
 };
 
 #endif /* SUBMIT_ARGS_H_ */

--- a/tools/benchmark/submit_parse.c
+++ b/tools/benchmark/submit_parse.c
@@ -13,8 +13,8 @@ static char doc[] = "Benchmark sequential submit requests\n";
 /* Order of fields: {NAME, KEY, ARG, FLAGS, DOC, GROUP}.*/
 static struct argp_option options[] = {
     {"dir", 'd', "DIR", 0, "Directory to use for temp files (default '.')", 0},
-    {"size", 's', "S", 0, "Size of each submitted entry (default 4k)", 0},
-    {"n", 'n', "N", 0, "Total number of entries to submit (default 2048)", 0},
+    {"buf", 'b', "BUF", 0, "Size of each entry to submit (default 4096)", 0},
+    {"size", 's', "S", 0, "Total number of bytes to submit (default 8M)", 0},
     {0}};
 
 static error_t argpParser(int key, char *arg, struct argp_state *state);
@@ -33,11 +33,11 @@ static error_t argpParser(int key, char *arg, struct argp_state *state)
         case 'd':
             opts->dir = arg;
             break;
+        case 'b':
+            opts->buf = (unsigned)atoi(arg);
+            break;
         case 's':
             opts->size = (unsigned)atoi(arg);
-            break;
-        case 'n':
-            opts->n = (unsigned)atoi(arg);
             break;
         default:
             return ARGP_ERR_UNKNOWN;
@@ -49,18 +49,18 @@ static error_t argpParser(int key, char *arg, struct argp_state *state)
 static void optionsInit(struct submitOptions *opts)
 {
     opts->dir = ".";
-    opts->size = 4096;
-    opts->n = 2048;
+    opts->buf = 2048;
+    opts->size = 8 * MEGABYTE;
 }
 
 static void optionsCheck(struct submitOptions *opts)
 {
-    if (opts->size == 0 || (opts->size % 4096) != 0) {
-        printf("Invalid buffer entry size %zu\n", opts->size);
+    if (opts->buf == 0 || opts->buf > MEGABYTE) {
+        printf("Invalid buffer entry size %zu\n", opts->buf);
         exit(1);
     }
-    if (opts->n == 0) {
-        printf("Invalid number of submissions %u\n", opts->n);
+    if (opts->size == 0 || opts->size % 4096 != 0) {
+        printf("Invalid total submission size %u\n", opts->size);
         exit(1);
     }
 }


### PR DESCRIPTION
The command line flags now match the ones of "benchmark disk".
