### PR TITLE
uv/append: Don't call uvMaybeFireCloseCb in uvAliveSegmentWriterCloseCb

### DIFF
--- a/src/uv_append.c
+++ b/src/uv_append.c
@@ -74,10 +74,8 @@ struct uvAppend
 static void uvAliveSegmentWriterCloseCb(struct UvWriter *writer)
 {
     struct uvAliveSegment *segment = writer->data;
-    struct uv *uv = segment->uv;
     uvSegmentBufferClose(&segment->pending);
     RaftHeapFree(segment);
-    uvMaybeFireCloseCb(uv);
 }
 
 /* Submit a request to close the current open segment. */


### PR DESCRIPTION
We actually don't track that there are pending segment writer close operations, so this call to uvMaybeFireCloseCb() can't really unblock anything waiting on it.

On the contrary, if it fires after the close callback has actually been fired, it causes a double free:

 ==199067==ERROR: AddressSanitizer: attempting double-free on 0x602000000010 in thread T0:
    #0 0x7fd5e44d7288 in __interceptor_free ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:52
    #1 0x7fd5e4b5a259 in ioCloseCb src/raft.c:115
    #2 0x7fd5e4b84861 in uvMaybeFireCloseCbReal src/uv.c:202
    #3 0x7fd5e4afba70 in uv_run (/lib/x86_64-linux-gnu/libuv.so.1+0xfa70) (BuildId: 7f7f8c148150666c7b116bf98bf6e27f96c697a9)
    #4 0x55b25438ebe5 in SubmitRun tools/benchmark/submit.c:314
    #5 0x55b254388955 in main tools/benchmark/main.c:60
    #6 0x7fd5e42456c9  (/lib/x86_64-linux-gnu/libc.so.6+0x276c9) (BuildId: 072feb34c63e054d60d94cbc68d92e4caad25d72)
    #7 0x7fd5e4245784 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x27784) (BuildId: 072feb34c63e054d60d94cbc68d92e4caad25d72)
    #8 0x55b254388bf0 in _start (/home/free/src/c/raft/tools/.libs/raft-benchmark+0x7bf0) (BuildId: 09105ce7d1a7fe71ca812de2af648a85fc490ebb)

0x602000000010 is located 0 bytes inside of 15-byte region [0x602000000010,0x60200000001f) freed by thread T0 here:
    #0 0x7fd5e44d7288 in __interceptor_free ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:52
    #1 0x7fd5e4b5a259 in ioCloseCb src/raft.c:115
    #2 0x7fd5e4b84861 in uvMaybeFireCloseCbReal src/uv.c:202
    #3 0x7fd5e4afba70 in uv_run (/lib/x86_64-linux-gnu/libuv.so.1+0xfa70) (BuildId: 7f7f8c148150666c7b116bf98bf6e27f96c697a9)

previously allocated by thread T0 here:
    #0 0x7fd5e44d85bf in __interceptor_malloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:69
    #1 0x7fd5e4b59983 in raft_init src/raft.c:62
    #2 0x55b25438e7d4 in serverInit tools/benchmark/submit.c:127
    #3 0x55b25438ebbf in SubmitRun tools/benchmark/submit.c:302
    #4 0x55b254388955 in main tools/benchmark/main.c:60
    #5 0x7fd5e42456c9  (/lib/x86_64-linux-gnu/libc.so.6+0x276c9) (BuildId: 072feb34c63e054d60d94cbc68d92e4caad25d72)