### PR TITLE
benchmark/submit: Report performance of disk writes

### DIFF
--- a/include/raft/uv.h
+++ b/include/raft/uv.h
@@ -5,6 +5,12 @@
 
 #include "../raft.h"
 
+/**
+ * Trace events fired when a disk write gets submitted and completed.
+ */
+#define RAFT_UV_TRACER_WRITE_SUBMIT (1 << 8)
+#define RAFT_UV_TRACER_WRITE_COMPLETE (2 << 8)
+
 struct raft_uv_transport;
 
 /**

--- a/src/tracing.h
+++ b/src/tracing.h
@@ -14,7 +14,16 @@ extern struct raft_tracer NoopTracer;
 /* Default stderr tracer. */
 extern struct raft_tracer StderrTracer;
 
-/* Emit a message with the given tracer at level 5. */
+/* Use TRACER to trace an event of type TYPE with the given INFO. */
+#define Trace(TRACER, TYPE, INFO)          \
+    do {                                   \
+        if (LIKELY(TRACER == NULL)) {      \
+            break;                         \
+        }                                  \
+        TRACER->trace(TRACER, TYPE, INFO); \
+    } while (0)
+
+/* Emit diagnostic message with the given tracer at level 5. */
 #define Tracef(TRACER, ...) Logf(TRACER, 5, __VA_ARGS__)
 
 /* Use the tracer to log an event at the given level.

--- a/src/tracing.h
+++ b/src/tracing.h
@@ -15,12 +15,14 @@ extern struct raft_tracer NoopTracer;
 extern struct raft_tracer StderrTracer;
 
 /* Use TRACER to trace an event of type TYPE with the given INFO. */
-#define Trace(TRACER, TYPE, INFO)          \
-    do {                                   \
-        if (LIKELY(TRACER == NULL)) {      \
-            break;                         \
-        }                                  \
-        TRACER->trace(TRACER, TYPE, INFO); \
+#define Trace(TRACER, TYPE, INFO)              \
+    do {                                       \
+        if (LIKELY(TRACER == NULL)) {          \
+            break;                             \
+        }                                      \
+        if (LIKELY(TRACER->version == 2)) {    \
+            TRACER->trace(TRACER, TYPE, INFO); \
+        }                                      \
     } while (0)
 
 /* Emit diagnostic message with the given tracer at level 5. */

--- a/src/uv_append.c
+++ b/src/uv_append.c
@@ -421,6 +421,7 @@ static int uvAliveSegmentReady(struct uv *uv,
         ErrMsgWrapf(uv->io->errmsg, "setup writer for open-%llu", counter);
         return rv;
     }
+    UvWriterSetTracer(&segment->writer, uv->tracer);
     segment->counter = counter;
     return 0;
 }

--- a/src/uv_writer.c
+++ b/src/uv_writer.c
@@ -4,8 +4,12 @@
 #include <unistd.h>
 
 #include "../include/raft.h"
+#include "../include/raft/uv.h"
 #include "assert.h"
 #include "heap.h"
+#include "tracing.h"
+
+#define trace(TYPE, INFO) Trace(w->tracer, TYPE, INFO)
 
 /* Copy the error message from the request object to the writer object. */
 static void uvWriterReqTransferErrMsg(struct UvWriterReq *req)
@@ -32,6 +36,8 @@ static void uvWriterReqSetStatus(struct UvWriterReq *req, int result)
  * callback if set. */
 static void uvWriterReqFinish(struct UvWriterReq *req)
 {
+    struct UvWriter *w = req->writer;
+    trace(RAFT_UV_TRACER_WRITE_COMPLETE, NULL);
     QUEUE_REMOVE(&req->queue);
     if (req->status != 0) {
         uvWriterReqTransferErrMsg(req);
@@ -437,6 +443,8 @@ int UvWriterSubmit(struct UvWriter *w,
     int rv = 0;
     struct iocb *iocbs = &req->iocb;
     assert(!w->closing);
+
+    trace(RAFT_UV_TRACER_WRITE_SUBMIT, NULL);
 
     /* TODO: at the moment we are not leveraging the support for concurrent
      *       writes, so ensure that we're getting write requests

--- a/src/uv_writer.c
+++ b/src/uv_writer.c
@@ -251,6 +251,7 @@ int UvWriterInit(struct UvWriter *w,
     QUEUE_INIT(&w->work_queue);
     w->closing = false;
     w->errmsg = errmsg;
+    w->tracer = NULL;
 
     /* Set direct I/O if available. */
     if (direct) {
@@ -408,6 +409,11 @@ void UvWriterClose(struct UvWriter *w, UvWriterCloseCb cb)
     } else {
         uv_close((struct uv_handle_s *)&w->check, uvWriterCheckCloseCb);
     }
+}
+
+void UvWriterSetTracer(struct UvWriter *w, struct raft_tracer *tracer)
+{
+    w->tracer = tracer;
 }
 
 /* Return the total lengths of the given buffers. */

--- a/src/uv_writer.h
+++ b/src/uv_writer.h
@@ -34,6 +34,8 @@ struct UvWriter
     queue work_queue;         /* Threadpool write requests */
     bool closing;             /* Whether we're closing or closed */
     char *errmsg;             /* Description of last error */
+
+    struct raft_tracer *tracer; /* Tracer to use */
 };
 
 /* Initialize a file writer. */
@@ -47,6 +49,9 @@ int UvWriterInit(struct UvWriter *w,
 
 /* Close the given file and release all associated resources. */
 void UvWriterClose(struct UvWriter *w, UvWriterCloseCb cb);
+
+/* Set a tracer on this writer. */
+void UvWriterSetTracer(struct UvWriter *w, struct raft_tracer *tracer);
 
 /* Write request. */
 struct UvWriterReq;

--- a/test/integration/test_uv_truncate.c
+++ b/test/integration/test_uv_truncate.c
@@ -142,7 +142,8 @@ static void tearDownDeps(void *data)
         munit_assert_int(_rv, ==, 0);                                        \
         _rv = raft_uv_init(&_io, &_loop, f->dir, &_transport);               \
         munit_assert_int(_rv, ==, 0);                                        \
-        _tracer.emit = TracerEmit;                                           \
+        _tracer.trace = TracerTrace;                                         \
+        _tracer.version = 2;                                                 \
         raft_uv_set_tracer(&_io, &_tracer);                                  \
         _rv = _io.init(&_io, 1, "1");                                        \
         munit_assert_int(_rv, ==, 0);                                        \

--- a/test/integration/test_uv_truncate_snapshot.c
+++ b/test/integration/test_uv_truncate_snapshot.c
@@ -150,7 +150,8 @@ static void tearDownDeps(void *data)
         munit_assert_int(_ret, ==, 0);                                    \
         _ret = raft_uv_init(&_io, &_loop, f->dir, &_transport);           \
         munit_assert_int(_ret, ==, 0);                                    \
-        _tracer.emit = TracerEmit;                                        \
+        _tracer.trace = TracerTrace;                                      \
+        _tracer.version = 2;                                              \
         raft_uv_set_tracer(&_io, &_tracer);                               \
         _ret = _io.init(&_io, 1, "1");                                    \
         munit_assert_int(_ret, ==, 0);                                    \

--- a/test/lib/tracer.c
+++ b/test/lib/tracer.c
@@ -2,11 +2,18 @@
 
 #include "munit.h"
 
-void TracerEmit(struct raft_tracer *t,
-                const char *file,
-                int line,
-                const char *message)
+static void traceDiagnostic(const struct raft_tracer_info *info)
+{
+    fprintf(stderr, "%20s:%*d - %s\n", info->diagnostic.file, 3,
+            info->diagnostic.line, info->diagnostic.message);
+}
+
+void TracerTrace(struct raft_tracer *t, int type, const void *info)
 {
     (void)t;
-    fprintf(stderr, "%20s:%*d - %s\n", file, 3, line, message);
+    switch (type) {
+        case RAFT_TRACER_DIAGNOSTIC:
+            traceDiagnostic(info);
+            break;
+    };
 }

--- a/test/lib/tracer.h
+++ b/test/lib/tracer.h
@@ -6,14 +6,13 @@
 #include "../../include/raft.h"
 
 #define FIXTURE_TRACER struct raft_tracer tracer
-#define SET_UP_TRACER            \
-    f->tracer.emit = TracerEmit; \
-    f->tracer.enabled = true
+#define SET_UP_TRACER                  \
+    do {                               \
+        f->tracer.trace = TracerTrace; \
+        f->tracer.version = 2;         \
+    } while (0)
 #define TEAR_DOWN_TRACER
 
-void TracerEmit(struct raft_tracer *t,
-                const char *file,
-                int line,
-                const char *message);
+void TracerTrace(struct raft_tracer *t, int type, const void *info);
 
 #endif /* TEST_TRACER_H */

--- a/tools/benchmark/disk_parse.c
+++ b/tools/benchmark/disk_parse.c
@@ -17,7 +17,7 @@ static struct argp_option options[] = {
     {"dir", 'd', "DIR", 0, "Directory to use for temp files (default '.')", 0},
     {"buf", 'b', "BUF", 0, "Write buffer size (default 4096)", 0},
     {"size", 's', "S", 0, "Size of the file to write (default 8M)", 0},
-    {"perf", 'p', NULL, 0, "Turn on kernel performance measuring", 0},
+    {"perf", 'p', NULL, 0, "Report kernel subsystems performance metrics", 0},
     {"trace", 't', "TRACE", 0, "Comma-separated kernel subsystems to trace", 0},
     {0}};
 

--- a/tools/benchmark/fs.c
+++ b/tools/benchmark/fs.c
@@ -19,6 +19,18 @@
 
 #define SYS_BLOCK_PATH "/sys/dev/block/%d:%d"
 
+/* Histgram resolution when the underlying block driver is NVMe. */
+#define RESOLUTION_NVME 500        /* buckets are 0.5 microseconds apart */
+#define BUCKETS_NVME 20 * 1000 * 2 /* buckets up to 20,000 microseconds */
+
+/* Histgram resolution when the underlying block driver is nullb. */
+#define RESOLUTION_NULLB 50     /* buckets are 50 nanoseconds apart */
+#define BUCKETS_NULLB 1000 * 20 /* buckets up to 1,000 microseconds */
+
+/* Histgram resolution when the underlying block driver is unspecified. */
+#define RESOLUTION_GENERIC 1000   /* buckets are 1 microsecond apart */
+#define BUCKETS_GENERIC 20 * 1000 /* buckets up to 20,000 microseconds */
+
 /* Read an integer value from the file /sys/dev/block/<maj>:<min>/name . */
 static int readBlockDeviceInfo(unsigned maj,
                                unsigned min,
@@ -169,6 +181,24 @@ int FsFileInfo(const char *path, struct FsFileInfo *info)
     }
 
 out:
+    switch (info->driver) {
+        case FS_DRIVER_NVME:
+            info->buckets = BUCKETS_NVME;
+            info->resolution = RESOLUTION_NVME;
+            break;
+        case FS_DRIVER_NULLB:
+            info->buckets = BUCKETS_NULLB;
+            info->resolution = RESOLUTION_NULLB;
+            break;
+        case FS_DRIVER_GENERIC:
+            info->buckets = BUCKETS_GENERIC;
+            info->resolution = RESOLUTION_GENERIC;
+            break;
+        default:
+            assert(0);
+            break;
+    }
+
     return 0;
 }
 

--- a/tools/benchmark/fs.h
+++ b/tools/benchmark/fs.h
@@ -20,8 +20,10 @@ enum {
 /* Hold information about a file. */
 struct FsFileInfo
 {
-    unsigned type;
-    unsigned driver;
+    unsigned type;            /* Regular file or device. */
+    unsigned driver;          /* Underlying block device driver */
+    unsigned buckets;         /* N. of buckets to use for histograms */
+    unsigned resolution;      /* Resolution to use for histograms */
     unsigned block_dev_start; /* First sector of the underlying block device */
     unsigned block_dev_end;   /* End sector of the underlying block device */
     bool block_dev_write_through; /* True if device has power-loss protection */

--- a/tools/benchmark/report.c
+++ b/tools/benchmark/report.c
@@ -4,10 +4,7 @@
 
 #include "report.h"
 
-void HistogramInit(struct histogram *h,
-                   unsigned n,
-                   unsigned long first,
-                   unsigned gap)
+void HistogramInit(struct histogram *h, unsigned n, unsigned gap)
 {
     unsigned i;
     assert(n >= 2);
@@ -17,7 +14,7 @@ void HistogramInit(struct histogram *h,
         h->buckets[i] = 0;
     }
     assert(h->buckets != NULL);
-    h->first = first;
+    h->first = gap;
     h->gap = gap;
 }
 

--- a/tools/benchmark/report.h
+++ b/tools/benchmark/report.h
@@ -37,10 +37,7 @@ struct report
 };
 
 /* Initialize a histogram object. */
-void HistogramInit(struct histogram *h,
-                   unsigned n,
-                   unsigned long first,
-                   unsigned gap);
+void HistogramInit(struct histogram *h, unsigned n, unsigned gap);
 
 void HistogramClose(struct histogram *h);
 


### PR DESCRIPTION
Add new tracing events to the libuv-based `raft_io` implementation to intercept the start and the end of disk writes, and use those events in the `raft-benchmark submit` command to report the latency of raw disk writes.