### PR TITLE
replication: For taking snapshots use commit_index, not last_applied

### DIFF
--- a/test/lib/fs.sh
+++ b/test/lib/fs.sh
@@ -63,7 +63,7 @@ if [ "${cmd}" = "setup" ]; then
 	    sudo mount -t tmpfs -o size=32m tmpfs ./tmp/tmpfs
 	else
 	    # Create a loopback disk device
-	    dd if=/dev/zero of="./tmp/.${type}" bs=4096 count=28672 > /dev/null 2>&1
+	    dd if=/dev/zero of="./tmp/.${type}" bs=4096 count=86016 > /dev/null 2>&1
 	    loop=$(sudo losetup -f)
 	    sudo losetup "${loop}" "./tmp/.${type}"
 


### PR DESCRIPTION
Currently entries are applied synchronously by the FSM as soon as they get committed.

However, we want to also support disk-based FSMs that might need to apply entries asynchronously. Using commit_index instead of last_applied when taking snapshots means that the raft engine will be able to request a snapshot even if some entries are still being applied by the FSM. Consumer code will queue the snapshot request and process it when outstanding entries have been applied.