### PR TITLE
uv/writer: Instead of opening files with O_DSYNC, use RWF_DSYNC

### DIFF
--- a/src/uv_fs.c
+++ b/src/uv_fs.c
@@ -193,9 +193,6 @@ int UvFsAllocateFile(const char *dir,
         return RAFT_INVALID;
     }
 
-    /* TODO: use RWF_DSYNC instead, if available. */
-    flags |= O_DSYNC;
-
     rv = uvFsOpenFile(dir, filename, flags, S_IRUSR | S_IWUSR, fd, errmsg);
     if (rv != 0) {
         goto err;

--- a/src/uv_writer.c
+++ b/src/uv_writer.c
@@ -477,18 +477,8 @@ int UvWriterSubmit(struct UvWriter *w,
     req->iocb.aio_offset = (int64_t)offset;
     *((void **)(&req->iocb.aio_data)) = (void *)req;
 
-#if defined(RWF_HIPRI)
-    /* High priority request, if possible */
-    /* TODO: do proper kernel feature detection for this one. */
-    /* req->iocb.aio_rw_flags |= RWF_HIPRI; */
-#endif
-
-#if defined(RWF_DSYNC)
-    /* Use per-request synchronous I/O if available. Otherwise, we have opened
-     * the file with O_DSYNC. */
-    /* TODO: do proper kernel feature detection for this one. */
-    /* req->iocb.aio_rw_flags |= RWF_DSYNC; */
-#endif
+    /* Use per-request synchronous I/O if available. */
+    req->iocb.aio_rw_flags |= RWF_DSYNC;
 
     /* If io_submit can be run in a 100% non-blocking way, we'll try to write
      * without using the threadpool. */

--- a/test/lib/fs.sh
+++ b/test/lib/fs.sh
@@ -22,15 +22,15 @@ types="tmpfs"
 if sudo losetup -f > /dev/null 2>&1; then
     types="$types ext4"
 
-    if [ "$(which mkfs.btrfs)" != "" ]; then
+    if [ "$(sudo which mkfs.btrfs)" != "" ]; then
         types="$types btrfs"
     fi
 
-    if [ "$(which mkfs.xfs)" != "" ]; then
+    if [ "$(sudo which mkfs.xfs)" != "" ]; then
         types="$types xfs"
     fi
 
-    if [ "$(which zfs)" != "" ]; then
+    if [ "$(sudo which zfs)" != "" ]; then
         types="$types zfs"
     fi
 


### PR DESCRIPTION
Use the per-request RWF_DSYNC flag (supported since Kernel 4.13), instead of opening the file with O_DSYNC.
