### PR TITLE
random: Add RandomRange() to generate a random number within a range

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -27,6 +27,7 @@ libraft_la_SOURCES = \
   src/log.c \
   src/membership.c \
   src/progress.c \
+  src/random.c \
   src/raft.c \
   src/recv.c \
   src/recv_append_entries.c \
@@ -69,6 +70,7 @@ test_unit_core_SOURCES = \
   src/flags.c \
   src/heap.c \
   src/log.c \
+  src/random.c \
   test/unit/main_core.c \
   test/unit/test_byte.c \
   test/unit/test_compress.c \
@@ -76,7 +78,8 @@ test_unit_core_SOURCES = \
   test/unit/test_err.c \
   test/unit/test_flags.c \
   test/unit/test_log.c \
-  test/unit/test_queue.c
+  test/unit/test_queue.c \
+  test/unit/test_random.c
 test_unit_core_CFLAGS = $(AM_CFLAGS) -Wno-conversion
 test_unit_core_LDADD = libtest.la
 

--- a/src/random.c
+++ b/src/random.c
@@ -1,0 +1,54 @@
+#include <stdint.h>
+
+#include "assert.h"
+#include "random.h"
+
+#define RANDOM_MULTIPLIER (747796405U)
+#define RANDOM_INCREMENT (1729U)
+
+static uint32_t randomAdvance(unsigned *random)
+{
+    uint32_t state;
+    uint32_t n;
+    state = *random;
+    n = ((state >> ((state >> 28) + 4)) ^ state) * (277803737U);
+    n ^= n >> 22;
+    *random = state * RANDOM_MULTIPLIER + RANDOM_INCREMENT;
+    return n;
+}
+
+/* Generate a random non-negative number with at most the given value. */
+static uint32_t randomAtMost(unsigned *random, uint32_t max)
+{
+    /* We want (UINT32_MAX + 1) % max, which in unsigned arithmetic is the same
+     * as (UINT32_MAX + 1 - max) % max = -max % max. We compute -max using not
+     * to avoid compiler warnings.
+     */
+    const uint32_t min = (~max + 1U) % max;
+    uint32_t x;
+
+    if (max == (~((uint32_t)0U))) {
+        return randomAdvance(random);
+    }
+
+    max++;
+
+    do {
+        x = randomAdvance(random);
+    } while (x < min);
+
+    return x % max;
+}
+
+unsigned RandomWithinRange(unsigned *state, unsigned min, unsigned max)
+{
+    uint64_t range = (uint64_t)max - (uint64_t)min;
+
+    assert(min <= max);
+
+    if (range > (~((uint32_t)0U))) {
+        range = (~((uint32_t)0U));
+    }
+
+    return min + (unsigned)randomAtMost(state, (uint32_t)range);
+}

--- a/src/random.h
+++ b/src/random.h
@@ -1,0 +1,9 @@
+/* Pseudo-random number generator. */
+
+#ifndef RAFT_RANDOM_H_
+#define RAFT_RANDOM_H_
+
+/* Generate a random number between min and max. */
+unsigned RandomWithinRange(unsigned *state, unsigned min, unsigned max);
+
+#endif /* RAFT_RANDOM_H_ */

--- a/test/unit/test_random.c
+++ b/test/unit/test_random.c
@@ -1,0 +1,49 @@
+#include "../../src/random.h"
+#include "../lib/runner.h"
+
+SUITE(RandomWithinRange)
+
+/* First generated number with the default seed. */
+TEST(RandomWithinRange, first, NULL, NULL, 0, NULL)
+{
+    unsigned random = 42;
+    unsigned n = RandomWithinRange(&random, 1000, 2000);
+    munit_assert_int(n, ==, 1650);
+    return MUNIT_OK;
+}
+
+/* Sequence of 10 numbers with the default seed. */
+TEST(RandomWithinRange, sequence, NULL, NULL, 0, NULL)
+{
+    unsigned random = 42;
+    unsigned n[10];
+    int i;
+    int j;
+    for (i = 0; i < 10; i++) {
+        n[i] = RandomWithinRange(&random, 1000, 2000);
+    }
+    for (i = 0; i < 9; i++) {
+        munit_assert_int(n[i], >=, 1000);
+        munit_assert_int(n[i], <=, 2000);
+        for (j = i + 1; j < 10; j++) {
+            munit_assert_int(n[i], !=, n[j]);
+        }
+    }
+    return MUNIT_OK;
+}
+
+/* Change the seed */
+TEST(RandomWithinRange, seed, NULL, NULL, 0, NULL)
+{
+    unsigned random = 0;
+    unsigned n;
+    int i;
+    int expected[20] = {1571, 1410, 1735, 1743, 1995, 1353, 1589,
+                        1478, 1753, 1367, 1112, 1216, 1727, 1057,
+                        1061, 1669, 1773, 1425, 1864, 1035};
+    for (i = 0; i < 20; i++) {
+        n = RandomWithinRange(&random, 1000, 2000);
+        munit_assert_int(n, ==, expected[i]);
+    }
+    return MUNIT_OK;
+}


### PR DESCRIPTION
This new builtin pseudo-random number generator will be used to eventually replace the `raft_io->random()` interface.