### PR TITLE
raft: Plug pseudor-random number generator

### DIFF
--- a/include/raft.h
+++ b/include/raft.h
@@ -651,10 +651,11 @@ struct raft_log;
     }
 
 /* Extended struct raft fields added after the v0.x ABI freeze. */
-#define RAFT__EXTENSIONS                                           \
-    struct                                                         \
-    {                                                              \
-        raft_time now; /* Current time, updated via raft_step() */ \
+#define RAFT__EXTENSIONS                                             \
+    struct                                                           \
+    {                                                                \
+        raft_time now;   /* Current time, updated via raft_step() */ \
+        unsigned random; /* Pseudo-random number generator state */  \
     }
 
 RAFT__ASSERT_COMPATIBILITY(RAFT__RESERVED, RAFT__EXTENSIONS);
@@ -886,6 +887,13 @@ RAFT_API int raft_init(struct raft *r,
                        const char *address);
 
 RAFT_API void raft_close(struct raft *r, raft_close_cb cb);
+
+/**
+ * Seed the state of the pseudo random number generator.
+ *
+ * This should be called only once, before calling raft_start().
+ */
+RAFT_API void raft_seed(struct raft *r, unsigned random);
 
 /**
  * Bootstrap this raft instance using the given configuration. The instance must

--- a/src/election.c
+++ b/src/election.c
@@ -4,6 +4,7 @@
 #include "configuration.h"
 #include "heap.h"
 #include "log.h"
+#include "random.h"
 #include "tracing.h"
 
 #define tracef(...) Tracef(r->tracer, __VA_ARGS__)
@@ -33,8 +34,8 @@ struct followerOrCandidateState *getFollowerOrCandidateState(struct raft *r)
 void electionResetTimer(struct raft *r)
 {
     struct followerOrCandidateState *state = getFollowerOrCandidateState(r);
-    unsigned timeout = (unsigned)r->io->random(r->io, (int)r->election_timeout,
-                                               2 * (int)r->election_timeout);
+    unsigned timeout = RandomWithinRange(&r->random, r->election_timeout,
+                                         2 * r->election_timeout);
     assert(timeout >= r->election_timeout);
     assert(timeout <= r->election_timeout * 2);
     state->randomized_election_timeout = timeout;

--- a/src/raft.c
+++ b/src/raft.c
@@ -1,5 +1,6 @@
 #include "../include/raft.h"
 
+#include <limits.h>
 #include <string.h>
 
 #include "assert.h"
@@ -101,6 +102,7 @@ int raft_init(struct raft *r,
         goto err_after_address_alloc;
     }
     r->now = r->io->time(r->io);
+    raft_seed(r, (unsigned)r->io->random(r->io, 0, INT_MAX));
     return 0;
 
 err_after_address_alloc:
@@ -131,6 +133,11 @@ void raft_close(struct raft *r, void (*cb)(struct raft *r))
     }
     r->close_cb = cb;
     r->io->close(r->io, ioCloseCb);
+}
+
+void raft_seed(struct raft *r, unsigned random)
+{
+    r->random = random;
 }
 
 void raft_set_election_timeout(struct raft *r, const unsigned msecs)


### PR DESCRIPTION
This plugs the internal PRNG into `struct raft`. For now the generator is seeded using `struct raft_io->random()`, but eventually it will be consumer's responsibility to initialize it.