### PR TITLE
v1: Use TaskPersistTermAndVote instead of raft_io->set_term/set_vote

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -23,6 +23,7 @@ libraft_la_SOURCES = \
   src/err.c \
   src/flags.c \
   src/heap.c \
+  src/legacy.c \
   src/lifecycle.c \
   src/log.c \
   src/membership.c \

--- a/Makefile.am
+++ b/Makefile.am
@@ -41,6 +41,7 @@ libraft_la_SOURCES = \
   src/start.c \
   src/state.c \
   src/syscall.c \
+  src/task.c \
   src/tick.c \
   src/tracing.c
 

--- a/include/raft.h
+++ b/include/raft.h
@@ -577,9 +577,13 @@ struct raft_task
     };
 };
 
+/**
+ * Type codes of events to be passed to raft_step().
+ */
 enum {
-    RAFT_DONE = 1,
-    RAFT_RECEIVE,
+    RAFT_DONE = 1, /* A task has been completed. */
+    RAFT_RECEIVE,  /* A message has been received. */
+    RAFT_TIMEOUT,  /* The timeout has expired. */
 };
 
 /**

--- a/include/raft.h
+++ b/include/raft.h
@@ -584,6 +584,8 @@ enum {
     RAFT_DONE = 1, /* A task has been completed. */
     RAFT_RECEIVE,  /* A message has been received. */
     RAFT_TIMEOUT,  /* The timeout has expired. */
+    RAFT_SUBMIT,   /* New entries have been submitted. */
+    RAFT_TRANSFER, /* Submission of leadership trasfer request */
 };
 
 /**

--- a/include/raft.h
+++ b/include/raft.h
@@ -577,7 +577,10 @@ struct raft_task
     };
 };
 
-enum { RAFT_DONE = 1 };
+enum {
+    RAFT_DONE = 1,
+    RAFT_RECEIVE,
+};
 
 /**
  * Represents an external event that drives the raft engine forward (for example
@@ -594,6 +597,12 @@ struct raft_event
             struct raft_task task;
             int status;
         } done;
+        struct
+        {
+            raft_id id;
+            const char *address;
+            struct raft_message *message;
+        } receive;
     };
 };
 

--- a/include/raft.h
+++ b/include/raft.h
@@ -557,12 +557,24 @@ enum {
 };
 
 /**
+ * Parameters of tasks of type #RAFT_PERSIST_TERM_AND_VOTE.
+ */
+struct raft_persist_term_and_vote
+{
+    raft_term term;
+    raft_id voted_for;
+};
+
+/**
  * Represents a task that can be queued and executed asynchronously.
  */
 struct raft_task
 {
     unsigned char type;
     unsigned char reserved[7];
+    union {
+        struct raft_persist_term_and_vote persist_term_and_vote;
+    };
 };
 
 enum { RAFT_DONE = 1 };

--- a/src/legacy.c
+++ b/src/legacy.c
@@ -1,0 +1,112 @@
+#include "legacy.h"
+#include "assert.h"
+
+static struct raft_event *eventAppend(struct raft_event *events[],
+                                      unsigned *n_events)
+{
+    struct raft_event *array;
+
+    array = raft_realloc(*events, sizeof **events * (*n_events + 1));
+    if (array == NULL) {
+        return NULL;
+    }
+
+    *n_events += 1;
+
+    return &(*events)[*n_events - 1];
+}
+
+static int ioPersistTermAndVote(struct raft *r,
+                                struct raft_task *task,
+                                struct raft_event *events[],
+                                unsigned *n_events)
+{
+    struct raft_persist_term_and_vote *params = &task->persist_term_and_vote;
+    struct raft_event *event;
+    int rv;
+
+    rv = r->io->set_term(r->io, params->term);
+    if (rv != 0) {
+        goto err;
+    }
+
+    rv = r->io->set_vote(r->io, params->voted_for);
+    if (rv != 0) {
+        goto err;
+    }
+
+    /* Add a completion event immediately, since set_term() and set_vote() are
+     * required to be synchronous */
+    event = eventAppend(events, n_events);
+    if (event == NULL) {
+        rv = RAFT_NOMEM;
+        goto err;
+    }
+    event->type = RAFT_DONE;
+    event->time = r->io->time(r->io);
+    event->done.task.type = RAFT_PERSIST_TERM_AND_VOTE;
+    event->done.status = 0;
+
+    return 0;
+
+err:
+    return rv;
+}
+
+int LegacyForwardToRaftIo(struct raft *r, struct raft_event *event)
+{
+    struct raft_event *events;
+    unsigned n_events;
+    unsigned i;
+    int rv;
+
+    if (r->io == NULL) {
+        /* No legacy raft_io implementation, just do nothing. */
+        return 0;
+    }
+
+    /* Initially the set of events contains only the event passed as argument,
+     * but might grow if some of the tasks get completed synchronously. */
+    events = event;
+    n_events = 1;
+
+    for (i = 0; i < n_events; i++) {
+        struct raft_task *tasks;
+        unsigned n_tasks;
+        raft_time timeout;
+        unsigned j;
+
+        event = &events[i];
+
+        rv = raft_step(r, event, &timeout, &tasks, &n_tasks);
+        if (rv != 0) {
+            goto err;
+        }
+
+        for (j = 0; j < n_tasks; j++) {
+            struct raft_task *task = &tasks[j];
+
+            switch (task->type) {
+                case RAFT_PERSIST_TERM_AND_VOTE:
+                    rv = ioPersistTermAndVote(r, task, &events, &n_events);
+                    break;
+                default:
+                    rv = RAFT_INVALID;
+                    assert(0);
+                    break;
+            };
+
+            if (rv != 0) {
+                goto err;
+            }
+        }
+    }
+
+    return 0;
+err:
+    if (n_events > 1) {
+        raft_free(events);
+    }
+
+    return rv;
+}

--- a/src/legacy.h
+++ b/src/legacy.h
@@ -1,0 +1,12 @@
+/* Compatibility layer between v1.x and v0.x. */
+
+#ifndef RAFT_LEGACY_H_
+#define RAFT_LEGACY_H_
+
+#include "../include/raft.h"
+
+/* Pass the given event to raft_step() and execute the resulting tasks using the
+ * legacy raft_io interface. */
+int LegacyForwardToRaftIo(struct raft *r, struct raft_event *event);
+
+#endif /* RAFT_LEGACY_H_ */

--- a/src/recv.c
+++ b/src/recv.c
@@ -4,6 +4,7 @@
 #include "convert.h"
 #include "entry.h"
 #include "heap.h"
+#include "legacy.h"
 #include "log.h"
 #include "membership.h"
 #include "recv_append_entries.h"
@@ -86,7 +87,9 @@ static int recvMessage(struct raft *r, struct raft_message *message)
 void recvCb(struct raft_io *io, struct raft_message *message)
 {
     struct raft *r = io->data;
+    struct raft_event event;
     int rv;
+
     r->now = r->io->time(r->io);
     if (r->state == RAFT_UNAVAILABLE) {
         switch (message->type) {
@@ -103,8 +106,24 @@ void recvCb(struct raft_io *io, struct raft_message *message)
     }
     rv = recvMessage(r, message);
     if (rv != 0) {
-        convertToUnavailable(r);
+        goto err;
     }
+
+    event.type = RAFT_RECEIVE;
+    event.time = r->now;
+    event.receive.id = message->server_id;
+    event.receive.address = message->server_address;
+    event.receive.message = message;
+
+    rv = LegacyForwardToRaftIo(r, &event);
+    if (rv != 0) {
+        goto err;
+    }
+
+    return;
+
+err:
+    convertToUnavailable(r);
 }
 
 int recvBumpCurrentTerm(struct raft *r, raft_term term)

--- a/src/recv.c
+++ b/src/recv.c
@@ -14,6 +14,7 @@
 #include "recv_request_vote_result.h"
 #include "recv_timeout_now.h"
 #include "string.h"
+#include "task.h"
 #include "tracing.h"
 
 #define tracef(...) Tracef(r->tracer, __VA_ARGS__)
@@ -142,7 +143,7 @@ int recvBumpCurrentTerm(struct raft *r, raft_term term)
     tracef("%s", msg);
 
     /* Save the new term to persistent store, resetting the vote. */
-    rv = r->io->set_term(r->io, term);
+    rv = TaskPersistTermAndVote(r, term, 0);
     if (rv != 0) {
         return rv;
     }

--- a/src/task.c
+++ b/src/task.c
@@ -1,0 +1,57 @@
+#include "task.h"
+#include "assert.h"
+#include "heap.h"
+#include "queue.h"
+
+/* Append a new task to the r->tasks queue and return a pointer to it.
+ *
+ * Return RAFT_NOMEM if no-memory is available. */
+static struct raft_task *taskAppend(struct raft *r)
+{
+    struct raft_task *tasks;
+    unsigned n_tasks = r->n_tasks + 1;
+
+    if (n_tasks > r->n_tasks_cap) {
+        unsigned n_tasks_cap = r->n_tasks_cap;
+        if (n_tasks_cap == 0) {
+            n_tasks_cap = 16; /* Initial cap */
+        } else {
+            n_tasks_cap *= 2;
+        }
+        tasks = raft_realloc(r->tasks, sizeof *r->tasks * n_tasks_cap);
+        if (tasks == NULL) {
+            return NULL;
+        }
+        r->tasks = tasks;
+        r->n_tasks_cap = n_tasks_cap;
+    }
+
+    r->n_tasks = n_tasks;
+
+    return &r->tasks[r->n_tasks - 1];
+}
+
+int TaskPersistTermAndVote(struct raft *r, raft_term term, raft_id voted_for)
+{
+    struct raft_task *task;
+    struct raft_persist_term_and_vote *params;
+    int rv;
+
+    task = taskAppend(r);
+    if (task == NULL) {
+        rv = RAFT_NOMEM;
+        goto err;
+    }
+
+    task->type = RAFT_PERSIST_TERM_AND_VOTE;
+
+    params = &task->persist_term_and_vote;
+    params->term = term;
+    params->voted_for = voted_for;
+
+    return 0;
+
+err:
+    assert(rv == RAFT_NOMEM);
+    return rv;
+}

--- a/src/task.h
+++ b/src/task.h
@@ -1,0 +1,18 @@
+/* Enqueue asynchronous tasks. */
+
+#ifndef RAFT_TASK_H_
+#define RAFT_TASK_H_
+
+#include "../include/raft.h"
+
+/* Create and enqueue a raft_persist_term_and_vote task to persist the given
+ * term and vote.
+ *
+ * Errors:
+ *
+ * RAFT_NOMEM
+ *     The r->tasks array could not be resized to fit the new task.
+ */
+int TaskPersistTermAndVote(struct raft *r, raft_term term, raft_id voted_for);
+
+#endif /* RAFT_TASK_H_ */


### PR DESCRIPTION
The code has been updated to use the new `TaskPersistTermAndVote()` function, which creates a new `struct task_task`, instead of using the `raft_io` interface.
