### PR TITLE
recv: Update `recvCb` to use only `raft_step()` to process a message

### DIFF
--- a/src/recv.c
+++ b/src/recv.c
@@ -20,10 +20,10 @@
 #define tracef(...) Tracef(r->tracer, __VA_ARGS__)
 
 /* Dispatch a single RPC message to the appropriate handler. */
-static int recvMessage(struct raft *r,
-                       raft_id id,
-                       const char *address,
-                       struct raft_message *message)
+int recvMessage(struct raft *r,
+                raft_id id,
+                const char *address,
+                struct raft_message *message)
 {
     int rv = 0;
 

--- a/src/recv.c
+++ b/src/recv.c
@@ -101,10 +101,6 @@ void recvCb(struct raft_io *io, struct raft_message *message)
         }
         return;
     }
-    rv = recvMessage(r, message->server_id, message->server_address, message);
-    if (rv != 0) {
-        goto err;
-    }
 
     event.type = RAFT_RECEIVE;
     event.time = r->now;

--- a/src/recv.h
+++ b/src/recv.h
@@ -5,6 +5,12 @@
 
 #include "../include/raft.h"
 
+/* Function to be invoked upon receiving an RPC message. */
+int recvMessage(struct raft *r,
+                raft_id id,
+                const char *address,
+                struct raft_message *message);
+
 /* Callback to be passed to the raft_io implementation. It will be invoked upon
  * receiving an RPC message. */
 void recvCb(struct raft_io *io, struct raft_message *message);


### PR DESCRIPTION
The `LegacyForwardToRaftIo()` function will now forward to `raft_step()` all messages received by the `struct raft_io` interface.
