### PR TITLE
Use a task to send RequestVote result messages

### DIFF
--- a/include/raft.h
+++ b/include/raft.h
@@ -557,6 +557,16 @@ enum {
 };
 
 /**
+ * Parameters of tasks of type #RAFT_SEND_MESSAGE.
+ */
+struct raft_send_message
+{
+    raft_id id;
+    const char *address; /* TODO: make a copy */
+    struct raft_message message;
+};
+
+/**
  * Parameters of tasks of type #RAFT_PERSIST_TERM_AND_VOTE.
  */
 struct raft_persist_term_and_vote
@@ -573,6 +583,7 @@ struct raft_task
     unsigned char type;
     unsigned char reserved[7];
     union {
+        struct raft_send_message send_message;
         struct raft_persist_term_and_vote persist_term_and_vote;
     };
 };

--- a/src/legacy.c
+++ b/src/legacy.c
@@ -1,5 +1,6 @@
 #include "legacy.h"
 #include "assert.h"
+#include "err.h"
 
 static struct raft_event *eventAppend(struct raft_event *events[],
                                       unsigned *n_events)
@@ -15,6 +16,65 @@ static struct raft_event *eventAppend(struct raft_event *events[],
     *n_events += 1;
 
     return &(*events)[*n_events - 1];
+}
+
+/* Call LegacyForwardToRaftIo() after an asynchronous task has been
+ * completed. */
+static void ioTaskDone(struct raft *r, struct raft_task *task, int status)
+{
+    struct raft_event event;
+    event.type = RAFT_DONE;
+    event.time = r->io->time(r->io);
+    event.done.task = *task;
+    event.done.status = status;
+    LegacyForwardToRaftIo(r, &event);
+}
+
+struct ioForwardSendMessage
+{
+    struct raft_io_send send;
+    struct raft *r;
+    struct raft_task task;
+};
+
+static void ioSendMessageCb(struct raft_io_send *send, int status)
+{
+    struct ioForwardSendMessage *req = send->data;
+    struct raft *r = req->r;
+    struct raft_task task = req->task;
+    raft_free(req);
+    ioTaskDone(r, &task, status);
+}
+
+static int ioSendMessage(struct raft *r, struct raft_task *task)
+{
+    struct raft_send_message *params = &task->send_message;
+    struct ioForwardSendMessage *req;
+    struct raft_message message;
+    int rv;
+
+    req = raft_malloc(sizeof *req);
+    if (req == NULL) {
+        return RAFT_NOMEM;
+    }
+    req->r = r;
+    req->task = *task;
+    req->send.data = req;
+
+    message = params->message;
+    message.server_id = params->id;
+    message.server_address = params->address;
+
+    rv = r->io->send(r->io, &req->send, &message, ioSendMessageCb);
+    if (rv != 0) {
+        raft_free(req);
+        ErrMsgTransferf(r->io->errmsg, r->errmsg,
+                        "send message of type %d to %llu", params->message.type,
+                        params->id);
+        return rv;
+    }
+
+    return 0;
 }
 
 static int ioPersistTermAndVote(struct raft *r,
@@ -67,6 +127,8 @@ int LegacyForwardToRaftIo(struct raft *r, struct raft_event *event)
     }
 
     /* Initially the set of events contains only the event passed as argument,
+
+
      * but might grow if some of the tasks get completed synchronously. */
     events = raft_malloc(sizeof *events);
     if (events == NULL) {
@@ -92,6 +154,9 @@ int LegacyForwardToRaftIo(struct raft *r, struct raft_event *event)
             struct raft_task *task = &tasks[j];
 
             switch (task->type) {
+                case RAFT_SEND_MESSAGE:
+                    rv = ioSendMessage(r, task);
+                    break;
                 case RAFT_PERSIST_TERM_AND_VOTE:
                     rv = ioPersistTermAndVote(r, task, &events, &n_events);
                     break;

--- a/src/raft.c
+++ b/src/raft.c
@@ -153,6 +153,9 @@ static int stepDone(struct raft *r, struct raft_task *task, int status)
     assert(task != NULL);
 
     switch (task->type) {
+        case RAFT_SEND_MESSAGE:
+            /* Ignore the status, in case of errors we'll retry. */
+            break;
         case RAFT_PERSIST_TERM_AND_VOTE:
             /* TODO: reason more about what todo upon errors */
             if (status != 0 && r->state != RAFT_UNAVAILABLE) {

--- a/src/task.c
+++ b/src/task.c
@@ -31,6 +31,35 @@ static struct raft_task *taskAppend(struct raft *r)
     return &r->tasks[r->n_tasks - 1];
 }
 
+int TaskSendMessage(struct raft *r,
+                    raft_id id,
+                    const char *address,
+                    struct raft_message *message)
+{
+    struct raft_task *task;
+    struct raft_send_message *params;
+    int rv;
+
+    task = taskAppend(r);
+    if (task == NULL) {
+        rv = RAFT_NOMEM;
+        goto err;
+    }
+
+    task->type = RAFT_SEND_MESSAGE;
+
+    params = &task->send_message;
+    params->id = id;
+    params->address = address;
+    params->message = *message;
+
+    return 0;
+
+err:
+    assert(rv == RAFT_NOMEM);
+    return rv;
+}
+
 int TaskPersistTermAndVote(struct raft *r, raft_term term, raft_id voted_for)
 {
     struct raft_task *task;

--- a/src/task.h
+++ b/src/task.h
@@ -5,6 +5,19 @@
 
 #include "../include/raft.h"
 
+/* Create and enqueue a raft_send_message task to send the given message to the
+ * server with the given ID and address.
+ *
+ * Errors:
+ *
+ * RAFT_NOMEM
+ *     The request object could not be allocated.
+ */
+int TaskSendMessage(struct raft *r,
+                    raft_id id,
+                    const char *address,
+                    struct raft_message *message);
+
 /* Create and enqueue a raft_persist_term_and_vote task to persist the given
  * term and vote.
  *


### PR DESCRIPTION
Instead of using `raft_io->send()` to send RequestVote result messages, create a task of type `RAFT_SEND_MESSAGE`.