### PR TITLE
v1: Use TaskLoadSnapshot() instead of raft_io->snapshot_get()

### DIFF
--- a/include/raft.h
+++ b/include/raft.h
@@ -756,6 +756,8 @@ struct raft_log;
         struct raft_task *tasks; /* Queue of pending raft_task operations */ \
         unsigned n_tasks;        /* Length of the task queue */              \
         unsigned n_tasks_cap;    /* Capacity of the task queue */            \
+        /* Index of the last snapshot that was taken */                      \
+        raft_index configuration_last_snapshot_index;                        \
     }
 
 RAFT__ASSERT_COMPATIBILITY(RAFT__RESERVED, RAFT__EXTENSIONS);

--- a/include/raft.h
+++ b/include/raft.h
@@ -557,7 +557,7 @@ enum {
 };
 
 /**
- * Parameters of tasks of type #RAFT_SEND_MESSAGE.
+ * Parameters for tasks of type #RAFT_SEND_MESSAGE.
  */
 struct raft_send_message
 {
@@ -567,7 +567,7 @@ struct raft_send_message
 };
 
 /**
- * Parameters of tasks of type #RAFT_PERSIST_TERM_AND_VOTE.
+ * Parameters for tasks of type #RAFT_PERSIST_TERM_AND_VOTE.
  */
 struct raft_persist_term_and_vote
 {

--- a/include/raft.h
+++ b/include/raft.h
@@ -576,6 +576,17 @@ struct raft_persist_term_and_vote
 };
 
 /**
+ * Parameters for tasks of type #RAFT_LOAD_SNAPSHOT.
+ */
+struct raft_load_snapshot
+{
+    raft_index index;         /* Index of last entry in the snapshot */
+    size_t offset;            /* Load snapshot data starting from this offset */
+    struct raft_buffer chunk; /* Load data into this buffer */
+    bool last;                /* OUTPUT: Whether this was the last chunk */
+};
+
+/**
  * Represents a task that can be queued and executed asynchronously.
  */
 struct raft_task
@@ -585,6 +596,7 @@ struct raft_task
     union {
         struct raft_send_message send_message;
         struct raft_persist_term_and_vote persist_term_and_vote;
+        struct raft_load_snapshot load_snapshot;
     };
 };
 

--- a/src/legacy.c
+++ b/src/legacy.c
@@ -128,8 +128,8 @@ static void ioForwardLoadSnapshotCb(struct raft_io_snapshot_get *get,
 {
     struct ioForwardLoadSnapshot *req = get->data;
     struct raft *r = req->r;
-    struct raft_task *task = &req->task;
-    struct raft_load_snapshot *params = &task->load_snapshot;
+    struct raft_task task = req->task;
+    struct raft_load_snapshot *params = &task.load_snapshot;
 
     if (status == 0) {
         assert(snapshot->index == params->index);
@@ -141,7 +141,7 @@ static void ioForwardLoadSnapshotCb(struct raft_io_snapshot_get *get,
     }
 
     raft_free(req);
-    ioTaskDone(r, task, status);
+    ioTaskDone(r, &task, status);
 }
 
 static int ioForwardLoadSnapshot(struct raft *r, struct raft_task *task)

--- a/src/progress.c
+++ b/src/progress.c
@@ -20,10 +20,10 @@ static void initProgress(struct raft_progress *p, raft_index last_index)
 {
     p->next_index = last_index + 1;
     p->match_index = 0;
-    p->snapshot_index = 0;
     p->last_send = 0;
-    p->snapshot_last_send = 0;
     p->recent_recv = false;
+    p->snapshot.index = 0;
+    p->snapshot.last_send = 0;
     p->state = PROGRESS__PROBE;
     p->features = 0;
 }
@@ -120,7 +120,7 @@ bool progressShouldReplicate(struct raft *r, unsigned i)
     switch (p->state) {
         case PROGRESS__SNAPSHOT:
             /* Snapshot timed out, move to PROBE */
-            if (r->now - p->snapshot_last_send >= r->install_snapshot_timeout) {
+            if (r->now - p->snapshot.last_send >= r->install_snapshot_timeout) {
                 tracef("snapshot timed out for index:%u", i);
                 result = true;
                 progressAbortSnapshot(r, i);
@@ -161,7 +161,7 @@ void progressUpdateLastSend(struct raft *r, unsigned i)
 
 void progressUpdateSnapshotLastSend(struct raft *r, unsigned i)
 {
-    r->leader_state.progress[i].snapshot_last_send = r->now;
+    r->leader_state.progress[i].snapshot.last_send = r->now;
 }
 
 bool progressResetRecentRecv(struct raft *r, const unsigned i)
@@ -197,13 +197,13 @@ void progressToSnapshot(struct raft *r, unsigned i)
 {
     struct raft_progress *p = &r->leader_state.progress[i];
     p->state = PROGRESS__SNAPSHOT;
-    p->snapshot_index = logSnapshotIndex(r->log);
+    p->snapshot.index = logSnapshotIndex(r->log);
 }
 
 void progressAbortSnapshot(struct raft *r, const unsigned i)
 {
     struct raft_progress *p = &r->leader_state.progress[i];
-    p->snapshot_index = 0;
+    p->snapshot.index = 0;
     p->state = PROGRESS__PROBE;
 }
 
@@ -226,7 +226,7 @@ bool progressMaybeDecrement(struct raft *r,
     if (p->state == PROGRESS__SNAPSHOT) {
         /* The rejection must be stale or spurious if the rejected index does
          * not match the last snapshot index. */
-        if (rejected != p->snapshot_index) {
+        if (rejected != p->snapshot.index) {
             return false;
         }
         progressAbortSnapshot(r, i);
@@ -290,9 +290,9 @@ void progressToProbe(struct raft *r, const unsigned i)
      * been sent to this peer successfully, so we probe from snapshot_index +
      * 1.*/
     if (p->state == PROGRESS__SNAPSHOT) {
-        assert(p->snapshot_index > 0);
-        p->next_index = max(p->match_index + 1, p->snapshot_index);
-        p->snapshot_index = 0;
+        assert(p->snapshot.index > 0);
+        p->next_index = max(p->match_index + 1, p->snapshot.index);
+        p->snapshot.index = 0;
     } else {
         p->next_index = p->match_index + 1;
     }
@@ -309,7 +309,7 @@ bool progressSnapshotDone(struct raft *r, const unsigned i)
 {
     struct raft_progress *p = &r->leader_state.progress[i];
     assert(p->state == PROGRESS__SNAPSHOT);
-    return p->match_index >= p->snapshot_index;
+    return p->match_index >= p->snapshot.index;
 }
 
 #undef tracef

--- a/src/progress.c
+++ b/src/progress.c
@@ -24,6 +24,7 @@ static void initProgress(struct raft_progress *p, raft_index last_index)
     p->recent_recv = false;
     p->snapshot.index = 0;
     p->snapshot.last_send = 0;
+    p->snapshot.loading = false;
     p->state = PROGRESS__PROBE;
     p->features = 0;
 }
@@ -198,6 +199,21 @@ void progressToSnapshot(struct raft *r, unsigned i)
     struct raft_progress *p = &r->leader_state.progress[i];
     p->state = PROGRESS__SNAPSHOT;
     p->snapshot.index = logSnapshotIndex(r->log);
+    p->snapshot.loading = true;
+}
+
+unsigned progressSnapshotLoaded(struct raft *r, raft_index index)
+{
+    unsigned i;
+    for (i = 0; i < r->configuration.n; i++) {
+        struct raft_progress *p = &r->leader_state.progress[i];
+        if (p->state == PROGRESS__SNAPSHOT && p->snapshot.index == index &&
+            p->snapshot.loading) {
+            p->snapshot.loading = false;
+            break;
+        }
+    }
+    return i;
 }
 
 void progressAbortSnapshot(struct raft *r, const unsigned i)

--- a/src/progress.h
+++ b/src/progress.h
@@ -17,14 +17,17 @@ enum {
  */
 struct raft_progress
 {
-    unsigned short state;         /* Probe, pipeline or snapshot. */
-    raft_index next_index;        /* Next entry to send. */
-    raft_index match_index;       /* Highest index reported as replicated. */
-    raft_index snapshot_index;    /* Last index of most recent snapshot sent. */
-    raft_time last_send;          /* Timestamp of last AppendEntries RPC. */
-    raft_time snapshot_last_send; /* Timestamp of last InstallSnaphot RPC. */
-    bool recent_recv;    /* A msg was received within election timeout. */
-    raft_flags features; /* What the server is capable of. */
+    unsigned short state;   /* Probe, pipeline or snapshot. */
+    raft_index next_index;  /* Next entry to send. */
+    raft_index match_index; /* Highest index reported as replicated. */
+    raft_time last_send;    /* Timestamp of last AppendEntries RPC. */
+    bool recent_recv;       /* A msg was received within election timeout. */
+    raft_flags features;    /* What the server is capable of. */
+    struct
+    {
+        raft_index index;    /* Last index of most recent snapshot sent. */
+        raft_time last_send; /* Timestamp of last InstallSnaphot RPC. */
+    } snapshot;
 };
 
 /* Create and initialize the array of progress objects used by the leader to

--- a/src/progress.h
+++ b/src/progress.h
@@ -27,6 +27,7 @@ struct raft_progress
     {
         raft_index index;    /* Last index of most recent snapshot sent. */
         raft_time last_send; /* Timestamp of last InstallSnaphot RPC. */
+        bool loading;        /* True when waiting for raft_load_snapshot */
     } snapshot;
 };
 
@@ -93,6 +94,11 @@ void progressToProbe(struct raft *r, unsigned i);
 
 /* Convert to pipeline mode. */
 void progressToPipeline(struct raft *r, unsigned i);
+
+/* To be called once a RAFT_LOAD_SNAPSHOT task to load a snapshot has been
+ * completed successfully. If the i'th server in the configuration was waiting
+ * for this snapshot data, then return i. */
+unsigned progressSnapshotLoaded(struct raft *r, raft_index index);
 
 /* Abort snapshot mode and switch to back to probe.
  *

--- a/src/raft.c
+++ b/src/raft.c
@@ -80,6 +80,7 @@ int raft_init(struct raft *r,
     raft_configuration_init(&r->configuration_last_snapshot);
     r->configuration_committed_index = 0;
     r->configuration_uncommitted_index = 0;
+    r->configuration_last_snapshot_index = 0;
     r->election_timeout = DEFAULT_ELECTION_TIMEOUT;
     r->heartbeat_timeout = DEFAULT_HEARTBEAT_TIMEOUT;
     r->install_snapshot_timeout = DEFAULT_INSTALL_SNAPSHOT_TIMEOUT;

--- a/src/raft.c
+++ b/src/raft.c
@@ -157,12 +157,21 @@ static int sendMessageDone(struct raft *r, struct raft_task *task, int status)
         case RAFT_IO_APPEND_ENTRIES:
             rv = replicationSendAppendEntriesDone(r, params, status);
             break;
+        case RAFT_IO_INSTALL_SNAPSHOT:
+            rv = replicationSendInstallSnapshotDone(r, params, status);
+            break;
         default:
             /* Ignore the status, in case of errors we'll retry. */
             rv = 0;
             break;
     }
     return rv;
+}
+
+static int loadSnapshotDone(struct raft *r, struct raft_task *task, int status)
+{
+    struct raft_load_snapshot *params = &task->load_snapshot;
+    return replicationLoadSnapshotDone(r, params, status);
 }
 
 /* Handle the completion of a task. */
@@ -182,6 +191,9 @@ static int stepDone(struct raft *r, struct raft_task *task, int status)
                 convertToUnavailable(r);
             }
             rv = status;
+            break;
+        case RAFT_LOAD_SNAPSHOT:
+            rv = loadSnapshotDone(r, task, status);
             break;
         default:
             rv = 0;

--- a/src/replication.c
+++ b/src/replication.c
@@ -1543,6 +1543,11 @@ static void takeSnapshotCb(struct raft_io_snapshot_put *req, int status)
          * configuration change. */
         tracef("failed to backup last committed configuration.");
     }
+
+    /* Make also a copy of the index of the configuration contained in the
+     * snapshot, we'll need it in case we send out an InstallSnapshot RPC. */
+    r->configuration_last_snapshot_index = snapshot->configuration_index;
+
     logSnapshot(r->log, snapshot->index, r->snapshot.trailing);
 out:
     takeSnapshotClose(r, snapshot);

--- a/src/replication.h
+++ b/src/replication.h
@@ -95,10 +95,21 @@ int replicationApply(struct raft *r);
  *   matchIndex[i] >= N, and log[N].term == currentTerm: set commitIndex = N */
 void replicationQuorum(struct raft *r, const raft_index index);
 
-/* Called when a task for sending an AppendEntries message has been
- * completed. */
+/* Called when a RAFT_SEND_MESSAGE task for sending an AppendEntries message has
+ * been completed. */
 int replicationSendAppendEntriesDone(struct raft *r,
                                      struct raft_send_message *params,
                                      int status);
+
+/* Called when a RAFT_SEND_MESSAGE task for sending an InstallSnapshot message
+ * has been completed. */
+int replicationSendInstallSnapshotDone(struct raft *r,
+                                       struct raft_send_message *params,
+                                       int status);
+
+/* Called when a RAFT_LOAD_SNAPSHOT task has been completed. */
+int replicationLoadSnapshotDone(struct raft *r,
+                                struct raft_load_snapshot *params,
+                                int status);
 
 #endif /* REPLICATION_H_ */

--- a/src/snapshot.c
+++ b/src/snapshot.c
@@ -55,6 +55,10 @@ int snapshotRestore(struct raft *r, struct raft_snapshot *snapshot)
         return rv;
     }
 
+    /* Make also a copy of the index of the configuration contained in the
+     * snapshot, we'll need it in case we send out an InstallSnapshot RPC. */
+    r->configuration_last_snapshot_index = snapshot->configuration_index;
+
     configurationTrace(r, &r->configuration,
                        "configuration restore from snapshot");
 

--- a/src/task.c
+++ b/src/task.c
@@ -84,3 +84,28 @@ err:
     assert(rv == RAFT_NOMEM);
     return rv;
 }
+
+int TaskLoadSnapshot(struct raft *r, raft_index index, size_t offset)
+{
+    struct raft_task *task;
+    struct raft_load_snapshot *params;
+    int rv;
+
+    task = taskAppend(r);
+    if (task == NULL) {
+        rv = RAFT_NOMEM;
+        goto err;
+    }
+
+    task->type = RAFT_LOAD_SNAPSHOT;
+
+    params = &task->load_snapshot;
+    params->index = index;
+    params->offset = offset;
+
+    return 0;
+
+err:
+    assert(rv == RAFT_NOMEM);
+    return rv;
+}

--- a/src/task.h
+++ b/src/task.h
@@ -28,4 +28,14 @@ int TaskSendMessage(struct raft *r,
  */
 int TaskPersistTermAndVote(struct raft *r, raft_term term, raft_id voted_for);
 
+/* Create and enqueue a RAFT_LOAD_SNAPSHOT task to load a single chunk of the
+ * snapshot at the given index starting at the given offset.
+ *
+ * Errors:
+ *
+ * RAFT_NOMEM
+ *     The r->tasks array could not be resized to fit the new task.
+ */
+int TaskLoadSnapshot(struct raft *r, raft_index index, size_t offset);
+
 #endif /* RAFT_TASK_H_ */

--- a/src/task.h
+++ b/src/task.h
@@ -5,20 +5,20 @@
 
 #include "../include/raft.h"
 
-/* Create and enqueue a raft_send_message task to send the given message to the
+/* Create and enqueue a RAFT_SEND_MESSAGE task to send the given message to the
  * server with the given ID and address.
  *
  * Errors:
  *
  * RAFT_NOMEM
- *     The request object could not be allocated.
+ *     The r->tasks array could not be resized to fit the new task.
  */
 int TaskSendMessage(struct raft *r,
                     raft_id id,
                     const char *address,
                     struct raft_message *message);
 
-/* Create and enqueue a raft_persist_term_and_vote task to persist the given
+/* Create and enqueue a RAFT_PERSIST_TERM_AND_VOTE task to persist the given
  * term and vote.
  *
  * Errors:


### PR DESCRIPTION
The replication code has been updated to enqueue `RAFT_LOAD_SNAPSHOT` tasks instead of calling out to the legacy `raft_io->snapshot_get()` interface.
