### PR TITLE
v1: Use TaskPersistEntries() instead of raft_io->append_entries

### DIFF
--- a/include/raft.h
+++ b/include/raft.h
@@ -567,6 +567,19 @@ struct raft_send_message
 };
 
 /**
+ * Parameters for tasks of type #RAFT_PERSIST_ENTRIES.
+ *
+ * Note that when writing an entry index at i, any previously-persisted entries
+ * with index >= i must be discarded.
+ */
+struct raft_persist_entries
+{
+    raft_index index;
+    struct raft_entry *entries;
+    unsigned n;
+};
+
+/**
  * Parameters for tasks of type #RAFT_PERSIST_TERM_AND_VOTE.
  */
 struct raft_persist_term_and_vote
@@ -597,6 +610,7 @@ struct raft_task
         struct raft_send_message send_message;
         struct raft_persist_term_and_vote persist_term_and_vote;
         struct raft_load_snapshot load_snapshot;
+        struct raft_persist_entries persist_entries;
     };
 };
 

--- a/src/raft.c
+++ b/src/raft.c
@@ -174,6 +174,14 @@ static int loadSnapshotDone(struct raft *r, struct raft_task *task, int status)
     return replicationLoadSnapshotDone(r, params, status);
 }
 
+static int persistEntriesDone(struct raft *r,
+                              struct raft_task *task,
+                              int status)
+{
+    struct raft_persist_entries *params = &task->persist_entries;
+    return replicationPersistEntriesDone(r, params, status);
+}
+
 /* Handle the completion of a task. */
 static int stepDone(struct raft *r, struct raft_task *task, int status)
 {
@@ -184,6 +192,9 @@ static int stepDone(struct raft *r, struct raft_task *task, int status)
     switch (task->type) {
         case RAFT_SEND_MESSAGE:
             rv = sendMessageDone(r, task, status);
+            break;
+        case RAFT_PERSIST_ENTRIES:
+            rv = persistEntriesDone(r, task, status);
             break;
         case RAFT_PERSIST_TERM_AND_VOTE:
             /* TODO: reason more about what todo upon errors */

--- a/src/replication.h
+++ b/src/replication.h
@@ -112,4 +112,9 @@ int replicationLoadSnapshotDone(struct raft *r,
                                 struct raft_load_snapshot *params,
                                 int status);
 
+/* Called when a RAFT_PERSIST_ENTRIES task has been completed. */
+int replicationPersistEntriesDone(struct raft *r,
+                                  struct raft_persist_entries *params,
+                                  int status);
+
 #endif /* REPLICATION_H_ */

--- a/src/task.c
+++ b/src/task.c
@@ -60,6 +60,35 @@ err:
     return rv;
 }
 
+int TaskPersistEntries(struct raft *r,
+                       raft_index index,
+                       struct raft_entry entries[],
+                       unsigned n)
+{
+    struct raft_task *task;
+    struct raft_persist_entries *params;
+    int rv;
+
+    task = taskAppend(r);
+    if (task == NULL) {
+        rv = RAFT_NOMEM;
+        goto err;
+    }
+
+    task->type = RAFT_PERSIST_ENTRIES;
+
+    params = &task->persist_entries;
+    params->index = index;
+    params->entries = entries;
+    params->n = n;
+
+    return 0;
+
+err:
+    assert(rv == RAFT_NOMEM);
+    return rv;
+}
+
 int TaskPersistTermAndVote(struct raft *r, raft_term term, raft_id voted_for)
 {
     struct raft_task *task;

--- a/src/task.h
+++ b/src/task.h
@@ -18,6 +18,19 @@ int TaskSendMessage(struct raft *r,
                     const char *address,
                     struct raft_message *message);
 
+/* Create and enqueue a RAFT_PERSIST_ENTRIES task to persist the given entries
+ * starting at the given index.
+ *
+ * Errors:
+ *
+ * RAFT_NOMEM
+ *     The r->tasks array could not be resized to fit the new task.
+ */
+int TaskPersistEntries(struct raft *r,
+                       raft_index first_index,
+                       struct raft_entry entries[],
+                       unsigned n);
+
 /* Create and enqueue a RAFT_PERSIST_TERM_AND_VOTE task to persist the given
  * term and vote.
  *


### PR DESCRIPTION
When leader,  enqueue `RAFT_PERSIST_ENTRIES` tasks instead of calling out to the legacy raft_io->append_entries() interface.

A similar change for the follower state will be pushed in a follow-up PR.