### PR TITLE
v1: Use raft_io->truncate() when handling RAFT_PERSIST_ENTRIES tasks

### DIFF
--- a/src/fixture.c
+++ b/src/fixture.c
@@ -636,7 +636,13 @@ static int ioMethodAppend(struct raft_io *raft_io,
 static int ioMethodTruncate(struct raft_io *raft_io, raft_index index)
 {
     struct io *io = raft_io->impl;
+    raft_index last_index = io->start_index + io->n;
     size_t n;
+
+    if (index >= last_index + 1) {
+        /* Nothing to truncate */
+        return 0;
+    }
 
     if (ioFaultTick(io)) {
         return RAFT_IOERR;

--- a/src/fixture.c
+++ b/src/fixture.c
@@ -144,6 +144,7 @@ struct io
     struct raft_snapshot *snapshot; /* Latest snapshot */
     struct raft_entry *entries;     /* Array or persisted entries */
     size_t n;                       /* Size of the persisted entries array */
+    raft_index start_index;
 
     /* Parameters passed via raft_io->init and raft_io->start */
     raft_id id;
@@ -311,6 +312,7 @@ static void ioFlushSnapshotPut(struct io *s, struct snapshot_put *r)
     if (r->trailing == 0) {
         rv = s->io->truncate(s->io, 1);
         assert(rv == 0);
+        s->start_index = s->snapshot->index;
     }
 
     if (r->req->cb != NULL) {
@@ -902,6 +904,7 @@ static int ioInit(struct raft_io *raft_io, unsigned index, raft_time *time)
     io->snapshot = NULL;
     io->entries = NULL;
     io->n = 0;
+    io->start_index = 0;
     QUEUE_INIT(&io->requests);
     io->n_peers = 0;
     io->randomized_election_timeout = ELECTION_TIMEOUT + index * 100;

--- a/src/replication.c
+++ b/src/replication.c
@@ -1020,10 +1020,6 @@ static int deleteConflictingEntries(struct raft *r,
 
             /* Delete all entries from this index on because they don't
              * match. */
-            rv = r->io->truncate(r->io, entry_index);
-            if (rv != 0) {
-                return rv;
-            }
             logTruncate(r->log, entry_index);
 
             /* Drop information about previously stored entries that have just

--- a/src/uv_truncate.c
+++ b/src/uv_truncate.c
@@ -164,9 +164,12 @@ int UvTruncate(struct raft_io *io, raft_index index)
     assert(!uv->closing);
 
     /* We should truncate only entries that we were requested to append in the
-     * first place. */
+     * first place. If the truncation index equals the next append index, this
+     * is a no-op. */
     assert(index > 0);
-    assert(index < uv->append_next_index);
+    if (index >= uv->append_next_index) {
+        return 0;
+    }
 
     truncate = RaftHeapMalloc(sizeof *truncate);
     if (truncate == NULL) {


### PR DESCRIPTION
Automatically use `raft_io->truncate()` when handling `RAFT_PERSIST_ENTRIES` tasks, so that call sites don't have to explicitly do that.

This is part of the contract of `RAFT_PERSIST_ENTRIES`, where all conflicting entries must be removed by the consumer code handling the task.
