### PR TITLE
v1: Use TaskPersistSnapshot() instead of raft_io->snapshot_put()

### DIFF
--- a/include/raft.h
+++ b/include/raft.h
@@ -615,6 +615,17 @@ struct raft_load_snapshot
 };
 
 /**
+ * Parameters for tasks of type #RAFT_PERSIST_SNAPSHOT.
+ */
+struct raft_persist_snapshot
+{
+    struct raft_snapshot_metadata metadata;
+    size_t offset;
+    struct raft_buffer chunk;
+    bool last;
+};
+
+/**
  * Represents a task that can be queued and executed asynchronously.
  */
 struct raft_task
@@ -626,6 +637,7 @@ struct raft_task
         struct raft_persist_term_and_vote persist_term_and_vote;
         struct raft_load_snapshot load_snapshot;
         struct raft_persist_entries persist_entries;
+        struct raft_persist_snapshot persist_snapshot;
     };
 };
 

--- a/include/raft.h
+++ b/include/raft.h
@@ -366,6 +366,21 @@ struct raft_message
 };
 
 /**
+ * Hold metadata associated with a snapshot.
+ */
+struct raft_snapshot_metadata
+{
+    /* Index and term of last entry included in the snapshot. */
+    raft_index index;
+    raft_term term;
+
+    /* Last committed configuration included in the snapshot, along with the
+     * index it was committed at. */
+    struct raft_configuration configuration;
+    raft_index configuration_index;
+};
+
+/**
  * Hold the details of a snapshot.
  * The user-provided raft_buffer structs should provide the user with enough
  * flexibility to adapt/evolve snapshot formats.

--- a/src/raft.c
+++ b/src/raft.c
@@ -182,6 +182,14 @@ static int persistEntriesDone(struct raft *r,
     return replicationPersistEntriesDone(r, params, status);
 }
 
+static int persistSnapshotDone(struct raft *r,
+                               struct raft_task *task,
+                               int status)
+{
+    struct raft_persist_snapshot *params = &task->persist_snapshot;
+    return replicationPersistSnapshotDone(r, params, status);
+}
+
 /* Handle the completion of a task. */
 static int stepDone(struct raft *r, struct raft_task *task, int status)
 {
@@ -202,6 +210,9 @@ static int stepDone(struct raft *r, struct raft_task *task, int status)
                 convertToUnavailable(r);
             }
             rv = status;
+            break;
+        case RAFT_PERSIST_SNAPSHOT:
+            rv = persistSnapshotDone(r, task, status);
             break;
         case RAFT_LOAD_SNAPSHOT:
             rv = loadSnapshotDone(r, task, status);

--- a/src/replication.h
+++ b/src/replication.h
@@ -117,4 +117,9 @@ int replicationPersistEntriesDone(struct raft *r,
                                   struct raft_persist_entries *params,
                                   int status);
 
+/* Called when a RAFT_PERSIST_SNAPSHOT task has been completed. */
+int replicationPersistSnapshotDone(struct raft *r,
+                                   struct raft_persist_snapshot *params,
+                                   int status);
+
 #endif /* REPLICATION_H_ */

--- a/src/snapshot.c
+++ b/src/snapshot.c
@@ -66,10 +66,6 @@ int snapshotRestore(struct raft *r, struct raft_snapshot *snapshot)
     r->last_applied = snapshot->index;
     r->last_stored = snapshot->index;
 
-    /* Don't free the snapshot data buffer, as ownership has been transferred to
-     * the fsm. */
-    raft_free(snapshot->bufs);
-
     return 0;
 }
 

--- a/src/start.c
+++ b/src/start.c
@@ -174,6 +174,9 @@ int raft_start(struct raft *r)
             entryBatchesDestroy(entries, n_entries);
             return rv;
         }
+        /* Don't free the snapshot data buffer, as ownership has been
+         * transferred to the fsm. */
+        raft_free(snapshot->bufs);
         snapshot_index = snapshot->index;
         snapshot_term = snapshot->term;
         raft_free(snapshot);

--- a/src/task.c
+++ b/src/task.c
@@ -114,6 +114,37 @@ err:
     return rv;
 }
 
+int TaskPersistSnapshot(struct raft *r,
+                        struct raft_snapshot_metadata metadata,
+                        size_t offset,
+                        struct raft_buffer chunk,
+                        bool last)
+{
+    struct raft_task *task;
+    struct raft_persist_snapshot *params;
+    int rv;
+
+    task = taskAppend(r);
+    if (task == NULL) {
+        rv = RAFT_NOMEM;
+        goto err;
+    }
+
+    task->type = RAFT_PERSIST_SNAPSHOT;
+
+    params = &task->persist_snapshot;
+    params->metadata = metadata;
+    params->offset = offset;
+    params->chunk = chunk;
+    params->last = last;
+
+    return 0;
+
+err:
+    assert(rv == RAFT_NOMEM);
+    return rv;
+}
+
 int TaskLoadSnapshot(struct raft *r, raft_index index, size_t offset)
 {
     struct raft_task *task;

--- a/src/task.h
+++ b/src/task.h
@@ -41,6 +41,20 @@ int TaskPersistEntries(struct raft *r,
  */
 int TaskPersistTermAndVote(struct raft *r, raft_term term, raft_id voted_for);
 
+/* Create and enqueue a RAFT_PERSIST_SNAPSHOT task to persist a single chunk of
+ * the snapshot with the given metadata, starting at the given offset.
+ *
+ * Errors:
+ *
+ * RAFT_NOMEM
+ *     The r->tasks array could not be resized to fit the new task.
+ */
+int TaskPersistSnapshot(struct raft *r,
+                        struct raft_snapshot_metadata metadata,
+                        size_t offset,
+                        struct raft_buffer chunk,
+                        bool last);
+
 /* Create and enqueue a RAFT_LOAD_SNAPSHOT task to load a single chunk of the
  * snapshot at the given index starting at the given offset.
  *


### PR DESCRIPTION
Update the code to enqueue a `RAFT_PERSIST_SNAPSHOT` task instead of calling out the legacy `raft_io->snapshot_put()` interface.
