### PR TITLE
v1: Use TaskApplyCommand() instead of raft_fsm->apply()

### DIFF
--- a/include/raft.h
+++ b/include/raft.h
@@ -626,6 +626,14 @@ struct raft_persist_snapshot
 };
 
 /**
+ * Parameters fork tasks of type #RAFT_APPLY_COMMAND.
+ */
+struct raft_apply_command
+{
+    raft_index index;
+    const struct raft_buffer *command;
+};
+/**
  * Represents a task that can be queued and executed asynchronously.
  */
 struct raft_task
@@ -638,6 +646,7 @@ struct raft_task
         struct raft_load_snapshot load_snapshot;
         struct raft_persist_entries persist_entries;
         struct raft_persist_snapshot persist_snapshot;
+        struct raft_apply_command apply_command;
     };
 };
 

--- a/src/legacy.c
+++ b/src/legacy.c
@@ -278,6 +278,38 @@ static int ioForwardLoadSnapshot(struct raft *r, struct raft_task *task)
     return 0;
 }
 
+static int ioForwardApplyCommand(struct raft *r,
+                                 struct raft_task *task,
+                                 struct raft_event *events[],
+                                 unsigned *n_events)
+{
+    struct raft_apply_command *params = &task->apply_command;
+    struct raft_event *event;
+    void *result;
+    int rv;
+    rv = r->fsm->apply(r->fsm, params->command, &result);
+    if (rv != 0) {
+        return rv;
+    }
+
+    /* Add a completion event immediately, since fsm->apply() is required to be
+     * synchronous */
+    event = eventAppend(events, n_events);
+    if (event == NULL) {
+        rv = RAFT_NOMEM;
+        goto err;
+    }
+
+    event->type = RAFT_DONE;
+    event->time = r->io->time(r->io);
+    event->done.task = *task;
+    event->done.status = 0;
+
+    return 0;
+err:
+    return rv;
+}
+
 int LegacyForwardToRaftIo(struct raft *r, struct raft_event *event)
 {
     struct raft_event *events;
@@ -332,6 +364,9 @@ int LegacyForwardToRaftIo(struct raft *r, struct raft_event *event)
                     break;
                 case RAFT_LOAD_SNAPSHOT:
                     rv = ioForwardLoadSnapshot(r, task);
+                    break;
+                case RAFT_APPLY_COMMAND:
+                    rv = ioForwardApplyCommand(r, task, &events, &n_events);
                     break;
                 default:
                     rv = RAFT_INVALID;

--- a/src/legacy.c
+++ b/src/legacy.c
@@ -155,7 +155,7 @@ static int ioPersistTermAndVote(struct raft *r,
     }
     event->type = RAFT_DONE;
     event->time = r->io->time(r->io);
-    event->done.task.type = RAFT_PERSIST_TERM_AND_VOTE;
+    event->done.task = *task;
     event->done.status = 0;
 
     return 0;

--- a/src/raft.c
+++ b/src/raft.c
@@ -190,6 +190,12 @@ static int persistSnapshotDone(struct raft *r,
     return replicationPersistSnapshotDone(r, params, status);
 }
 
+static int applyCommandDone(struct raft *r, struct raft_task *task, int status)
+{
+    struct raft_apply_command *params = &task->apply_command;
+    return replicationApplyCommandDone(r, params, status);
+}
+
 /* Handle the completion of a task. */
 static int stepDone(struct raft *r, struct raft_task *task, int status)
 {
@@ -216,6 +222,9 @@ static int stepDone(struct raft *r, struct raft_task *task, int status)
             break;
         case RAFT_LOAD_SNAPSHOT:
             rv = loadSnapshotDone(r, task, status);
+            break;
+        case RAFT_APPLY_COMMAND:
+            rv = applyCommandDone(r, task, status);
             break;
         default:
             rv = 0;

--- a/src/replication.h
+++ b/src/replication.h
@@ -122,4 +122,9 @@ int replicationPersistSnapshotDone(struct raft *r,
                                    struct raft_persist_snapshot *params,
                                    int status);
 
+/* Called when a RAFT_APPLY_COMMAND task has been completed. */
+int replicationApplyCommandDone(struct raft *r,
+                                struct raft_apply_command *params,
+                                int status);
+
 #endif /* REPLICATION_H_ */

--- a/src/task.c
+++ b/src/task.c
@@ -169,3 +169,30 @@ err:
     assert(rv == RAFT_NOMEM);
     return rv;
 }
+
+int TaskApplyCommand(struct raft *r,
+                     raft_index index,
+                     const struct raft_buffer *command)
+{
+    struct raft_task *task;
+    struct raft_apply_command *params;
+    int rv;
+
+    task = taskAppend(r);
+    if (task == NULL) {
+        rv = RAFT_NOMEM;
+        goto err;
+    }
+
+    task->type = RAFT_APPLY_COMMAND;
+
+    params = &task->apply_command;
+    params->index = index;
+    params->command = command;
+
+    return 0;
+
+err:
+    assert(rv == RAFT_NOMEM);
+    return rv;
+}

--- a/src/task.h
+++ b/src/task.h
@@ -65,4 +65,16 @@ int TaskPersistSnapshot(struct raft *r,
  */
 int TaskLoadSnapshot(struct raft *r, raft_index index, size_t offset);
 
+/* Create and enqueue a RAFT_APPLY_COMMAND task to apply to the application FSM
+ * the given command, contained in the entry at the given index.
+ *
+ * Errors:
+ *
+ * RAFT_NOMEM
+ *     The r->tasks array could not be resized to fit the new task.
+ */
+int TaskApplyCommand(struct raft *r,
+                     raft_index index,
+                     const struct raft_buffer *command);
+
 #endif /* RAFT_TASK_H_ */


### PR DESCRIPTION
Enqueue tasks of type `RAFT_APPLY_COMMAND` instead of calling out the legacy `raft_fsm->apply()` interface.