### PR TITLE
v1: Use TaskTakeSnapshot() instead of raft_fsm->apply()

### DIFF
--- a/include/raft.h
+++ b/include/raft.h
@@ -633,6 +633,15 @@ struct raft_apply_command
     raft_index index;
     const struct raft_buffer *command;
 };
+
+/**
+ * Parameters for tasks of type #RAFT_TAKE_SNAPSHOT.
+ */
+struct raft_take_snapshot
+{
+    struct raft_snapshot_metadata metadata;
+};
+
 /**
  * Represents a task that can be queued and executed asynchronously.
  */
@@ -647,6 +656,7 @@ struct raft_task
         struct raft_persist_entries persist_entries;
         struct raft_persist_snapshot persist_snapshot;
         struct raft_apply_command apply_command;
+        struct raft_take_snapshot take_snapshot;
     };
 };
 

--- a/src/raft.c
+++ b/src/raft.c
@@ -196,6 +196,12 @@ static int applyCommandDone(struct raft *r, struct raft_task *task, int status)
     return replicationApplyCommandDone(r, params, status);
 }
 
+static int takeSnapshotDone(struct raft *r, struct raft_task *task, int status)
+{
+    struct raft_take_snapshot *params = &task->take_snapshot;
+    return replicationTakeSnapshotDone(r, params, status);
+}
+
 /* Handle the completion of a task. */
 static int stepDone(struct raft *r, struct raft_task *task, int status)
 {
@@ -225,6 +231,9 @@ static int stepDone(struct raft *r, struct raft_task *task, int status)
             break;
         case RAFT_APPLY_COMMAND:
             rv = applyCommandDone(r, task, status);
+            break;
+        case RAFT_TAKE_SNAPSHOT:
+            rv = takeSnapshotDone(r, task, status);
             break;
         default:
             rv = 0;

--- a/src/replication.h
+++ b/src/replication.h
@@ -127,4 +127,9 @@ int replicationApplyCommandDone(struct raft *r,
                                 struct raft_apply_command *params,
                                 int status);
 
+/* Called when a RAFT_TAKE_SNAPSHOT task has been completed. */
+int replicationTakeSnapshotDone(struct raft *r,
+                                struct raft_take_snapshot *params,
+                                int status);
+
 #endif /* REPLICATION_H_ */

--- a/src/task.c
+++ b/src/task.c
@@ -196,3 +196,27 @@ err:
     assert(rv == RAFT_NOMEM);
     return rv;
 }
+
+int TaskTakeSnapshot(struct raft *r, struct raft_snapshot_metadata metadata)
+{
+    struct raft_task *task;
+    struct raft_take_snapshot *params;
+    int rv;
+
+    task = taskAppend(r);
+    if (task == NULL) {
+        rv = RAFT_NOMEM;
+        goto err;
+    }
+
+    task->type = RAFT_TAKE_SNAPSHOT;
+
+    params = &task->take_snapshot;
+    params->metadata = metadata;
+
+    return 0;
+
+err:
+    assert(rv == RAFT_NOMEM);
+    return rv;
+}

--- a/src/task.h
+++ b/src/task.h
@@ -77,4 +77,14 @@ int TaskApplyCommand(struct raft *r,
                      raft_index index,
                      const struct raft_buffer *command);
 
+/* Create and enqueue a RAFT_TAKE_SNAPSHOT task to take and persist a snapshot
+ * of the current application FSM state along with the given metadata.
+ *
+ * Errors:
+ *
+ * RAFT_NOMEM
+ *     The r->tasks array could not be resized to fit the new task.
+ */
+int TaskTakeSnapshot(struct raft *r, struct raft_snapshot_metadata metadata);
+
 #endif /* RAFT_TASK_H_ */


### PR DESCRIPTION
Enqueue a task of type `RAFT_TAKE_SNAPSHOT` in order to take a snapshot, instead of calling out to the legacy `raft_fsm->apply()` and `raft_io->snapshot_put()` interfaces.
