### PR TITLE
v1: Use TaskSnapshotRestore() instead of raft_fsm->restore()

### DIFF
--- a/include/raft.h
+++ b/include/raft.h
@@ -643,6 +643,14 @@ struct raft_take_snapshot
 };
 
 /**
+ * Parameters for tasks of type #RAFT_RESTORE_SNAPSHOT.
+ */
+struct raft_restore_snapshot
+{
+    raft_index index;
+};
+
+/**
  * Represents a task that can be queued and executed asynchronously.
  */
 struct raft_task
@@ -657,6 +665,7 @@ struct raft_task
         struct raft_persist_snapshot persist_snapshot;
         struct raft_apply_command apply_command;
         struct raft_take_snapshot take_snapshot;
+        struct raft_restore_snapshot restore_snapshot;
     };
 };
 

--- a/src/replication.c
+++ b/src/replication.c
@@ -1212,12 +1212,13 @@ int replicationPersistSnapshotDone(struct raft *r,
      *   8. Reset state machine using snapshot contents (and load lastConfig
      *      as cluster configuration).
      */
-    rv = r->fsm->restore(r->fsm, &snapshot.bufs[0]);
+    rv = TaskRestoreSnapshot(r, snapshot.index);
     if (rv != 0) {
         tracef("restore snapshot %llu: %s", snapshot.index,
                errCodeToString(rv));
         goto discard;
     }
+    raft_free(snapshot.bufs[0].base);
 
     rv = snapshotRestore(r, &snapshot);
     if (rv != 0) {

--- a/src/replication.c
+++ b/src/replication.c
@@ -1212,6 +1212,13 @@ int replicationPersistSnapshotDone(struct raft *r,
      *   8. Reset state machine using snapshot contents (and load lastConfig
      *      as cluster configuration).
      */
+    rv = r->fsm->restore(r->fsm, &snapshot.bufs[0]);
+    if (rv != 0) {
+        tracef("restore snapshot %llu: %s", snapshot.index,
+               errCodeToString(rv));
+        goto discard;
+    }
+
     rv = snapshotRestore(r, &snapshot);
     if (rv != 0) {
         tracef("restore snapshot %llu: %s", params->metadata.index,

--- a/src/snapshot.c
+++ b/src/snapshot.c
@@ -33,13 +33,6 @@ int snapshotRestore(struct raft *r, struct raft_snapshot *snapshot)
 
     assert(snapshot->n_bufs == 1);
 
-    rv = r->fsm->restore(r->fsm, &snapshot->bufs[0]);
-    if (rv != 0) {
-        tracef("restore snapshot %llu: %s", snapshot->index,
-               errCodeToString(rv));
-        return rv;
-    }
-
     configurationClose(&r->configuration);
     r->configuration = snapshot->configuration;
     r->configuration_committed_index = snapshot->configuration_index;

--- a/src/task.c
+++ b/src/task.c
@@ -220,3 +220,27 @@ err:
     assert(rv == RAFT_NOMEM);
     return rv;
 }
+
+int TaskRestoreSnapshot(struct raft *r, raft_index index)
+{
+    struct raft_task *task;
+    struct raft_restore_snapshot *params;
+    int rv;
+
+    task = taskAppend(r);
+    if (task == NULL) {
+        rv = RAFT_NOMEM;
+        goto err;
+    }
+
+    task->type = RAFT_RESTORE_SNAPSHOT;
+
+    params = &task->restore_snapshot;
+    params->index = index;
+
+    return 0;
+
+err:
+    assert(rv == RAFT_NOMEM);
+    return rv;
+}

--- a/src/task.h
+++ b/src/task.h
@@ -87,4 +87,14 @@ int TaskApplyCommand(struct raft *r,
  */
 int TaskTakeSnapshot(struct raft *r, struct raft_snapshot_metadata metadata);
 
+/* Create and enqueue a RAFT_TAKE_SNAPSHOT task to reset the state of the
+ * application FSM using the snapshot at the given index.
+ *
+ * Errors:
+ *
+ * RAFT_NOMEM
+ *     The r->tasks array could not be resized to fit the new task.
+ */
+int TaskRestoreSnapshot(struct raft *r, raft_index index);
+
 #endif /* RAFT_TASK_H_ */


### PR DESCRIPTION
Enqueue a `RAFT_SNAPSHOT_RESTORE` task instead of calling out to the legacy `raft_fsm->restore()` interface.
