### PR TITLE
raft.h: Re-add fsm->snapshot_async() method for backward compat

### DIFF
--- a/include/raft.h
+++ b/include/raft.h
@@ -785,6 +785,10 @@ struct raft_fsm
     int (*snapshot_finalize)(struct raft_fsm *fsm,
                              struct raft_buffer *bufs[],
                              unsigned *n_bufs);
+    /* Fields below added since version 3. */
+    int (*snapshot_async)(struct raft_fsm *fsm,
+                          struct raft_buffer *bufs[],
+                          unsigned *n_bufs);
 };
 
 /**

--- a/src/legacy.c
+++ b/src/legacy.c
@@ -403,6 +403,9 @@ static int ioForwardTakeSnapshot(struct raft *r,
     req->task = *task;
 
     rv = r->fsm->snapshot(r->fsm, &snapshot->bufs, &snapshot->n_bufs);
+    if (rv == 0 && r->fsm->version >= 3 && r->fsm->snapshot_async != NULL) {
+        rv = r->fsm->snapshot_async(r->fsm, &snapshot->bufs, &snapshot->n_bufs);
+    }
     if (rv != 0) {
         ErrMsgTransferf(r->io->errmsg, r->errmsg, "load snapshot at %llu",
                         params->metadata.index);


### PR DESCRIPTION
The disk-mode in dqlite depends on fsm->snapshot_async(), this commit re-adds it in a form that is sufficient to have dqlite tests pass.