### PR TITLE
replication: Limit the number of entries included in AppendEntries

### DIFF
--- a/src/log.c
+++ b/src/log.c
@@ -673,10 +673,11 @@ const struct raft_entry *logGet(struct raft_log *l, const raft_index index)
     return &l->entries[i];
 }
 
-int logAcquire(struct raft_log *l,
-               const raft_index index,
-               struct raft_entry *entries[],
-               unsigned *n)
+int logAcquireAtMost(struct raft_log *l,
+                     const raft_index index,
+                     unsigned max,
+                     struct raft_entry *entries[],
+                     unsigned *n)
 {
     size_t i;
     size_t j;
@@ -708,6 +709,10 @@ int logAcquire(struct raft_log *l,
 
     assert(*n > 0);
 
+    if (max > 0 && *n > max) {
+        *n = max;
+    }
+
     *entries = raft_calloc(*n, sizeof **entries);
     if (*entries == NULL) {
         return RAFT_NOMEM;
@@ -721,6 +726,14 @@ int logAcquire(struct raft_log *l,
     }
 
     return 0;
+}
+
+int logAcquire(struct raft_log *l,
+               raft_index index,
+               struct raft_entry *entries[],
+               unsigned *n)
+{
+    return logAcquireAtMost(l, index, 0, entries, n);
 }
 
 /* Return true if the given batch is referenced by any entry currently in the

--- a/src/log.h
+++ b/src/log.h
@@ -108,6 +108,15 @@ int logAppendConfiguration(struct raft_log *l,
                            const raft_term term,
                            const struct raft_configuration *configuration);
 
+/* Acquire at most @max entries from the given index onwards.
+ *
+ * If @max is 0, no limit is applied. */
+int logAcquireAtMost(struct raft_log *l,
+                     raft_index index,
+                     unsigned max,
+                     struct raft_entry *entries[],
+                     unsigned *n);
+
 /* Acquire an array of entries from the given index onwards.
  *
  * The payload memory referenced by the @buf attribute of the returned entries

--- a/src/replication.c
+++ b/src/replication.c
@@ -32,6 +32,12 @@
 #define min(a, b) ((a) < (b) ? (a) : (b))
 #endif
 
+/* Maximum number of entries that will be included in an AppendEntries
+ * message.
+ *
+ * TODO: Make this number configurable. */
+#define MAX_APPEND_ENTRIES 128
+
 /* Context of a RAFT_IO_APPEND_ENTRIES request that was submitted with
  * raft_io_>send(). */
 struct sendAppendEntries
@@ -85,8 +91,10 @@ static int sendAppendEntries(struct raft *r,
     args->prev_log_index = prev_index;
     args->prev_log_term = prev_term;
 
-    /* TODO: implement a limit to the total size of the entries being sent */
-    rv = logAcquire(r->log, next_index, &args->entries, &args->n_entries);
+    /* TODO: implement a limit to the total *size* of the entries being sent,
+     * not only the number. Also, make the number and the size configurable. */
+    rv = logAcquireAtMost(r->log, next_index, MAX_APPEND_ENTRIES,
+                          &args->entries, &args->n_entries);
     if (rv != 0) {
         goto err;
     }


### PR DESCRIPTION
Up to now there was no limit in the number of entries that a leader would send to a follower.

This introduces and hard-coded limit of 128, which at least prevents sending an unbounded number of entries.

Further refinements could make this limit configurable and/or also take into account the overall size of the entries being sent.
