### PR TITLE
replication: Revert eager update of commit index

### DIFF
--- a/include/raft.h
+++ b/include/raft.h
@@ -592,6 +592,7 @@ struct raft_persist_entries
     raft_index index;
     struct raft_entry *entries;
     unsigned n;
+    raft_index leader_commit;
 };
 
 /**

--- a/src/legacy.c
+++ b/src/legacy.c
@@ -240,7 +240,13 @@ static void ioForwardLoadSnapshotCb(struct raft_io_snapshot_get *get,
     struct raft_load_snapshot *params = &task.load_snapshot;
 
     if (status == 0) {
-        assert(snapshot->index == params->index);
+        /* The old raft_io interface makes no guarantee about the index of the
+         * loaded snapshot. */
+        if (snapshot->index != params->index) {
+            assert(snapshot->index > params->index);
+            params->index = snapshot->index;
+        }
+
         assert(snapshot->n_bufs == 1);
         params->chunk = snapshot->bufs[0];
         configurationClose(&snapshot->configuration);

--- a/src/legacy.c
+++ b/src/legacy.c
@@ -173,7 +173,6 @@ struct ioForwardPersistSnapshot
     struct raft_snapshot snapshot;
     struct raft *r;
     struct raft_task task;
-    struct raft_buffer chunk;
 };
 
 static void ioForwardPersistSnapshotCb(struct raft_io_snapshot_put *put,
@@ -188,8 +187,8 @@ static void ioForwardPersistSnapshotCb(struct raft_io_snapshot_put *put,
 
 static int ioForwardPersistSnapshot(struct raft *r, struct raft_task *task)
 {
-    struct raft_persist_snapshot *params = &task->persist_snapshot;
     struct ioForwardPersistSnapshot *req;
+    struct raft_persist_snapshot *params;
     int rv;
 
     req = raft_malloc(sizeof *req);
@@ -200,16 +199,13 @@ static int ioForwardPersistSnapshot(struct raft *r, struct raft_task *task)
     req->task = *task;
     req->put.data = req;
 
-    /* Copy the chunk in the request object, so it can be referenced later by
-     * req->snapshot.bufs. We can't reference the chunk directly since it's
-     * allocated on the stack. */
-    req->chunk = params->chunk;
+    params = &req->task.persist_snapshot;
 
     req->snapshot.index = params->metadata.index;
     req->snapshot.term = params->metadata.term;
     req->snapshot.configuration = params->metadata.configuration;
     req->snapshot.configuration_index = params->metadata.configuration_index;
-    req->snapshot.bufs = &req->chunk;
+    req->snapshot.bufs = &params->chunk;
     req->snapshot.n_bufs = 1;
 
     rv = r->io->snapshot_put(r->io, 0, &req->put, &req->snapshot,

--- a/src/task.c
+++ b/src/task.c
@@ -63,7 +63,8 @@ err:
 int TaskPersistEntries(struct raft *r,
                        raft_index index,
                        struct raft_entry entries[],
-                       unsigned n)
+                       unsigned n,
+                       raft_index leader_commit)
 {
     struct raft_task *task;
     struct raft_persist_entries *params;
@@ -81,6 +82,7 @@ int TaskPersistEntries(struct raft *r,
     params->index = index;
     params->entries = entries;
     params->n = n;
+    params->leader_commit = leader_commit;
 
     return 0;
 

--- a/src/task.h
+++ b/src/task.h
@@ -29,7 +29,8 @@ int TaskSendMessage(struct raft *r,
 int TaskPersistEntries(struct raft *r,
                        raft_index first_index,
                        struct raft_entry entries[],
-                       unsigned n);
+                       unsigned n,
+                       raft_index leader_commit);
 
 /* Create and enqueue a RAFT_PERSIST_TERM_AND_VOTE task to persist the given
  * term and vote.


### PR DESCRIPTION
This effectively reverts 70137cbb, which seems to break clustering tests for incus.
