### PR TITLE
Fix integration `raft_uv_transport` test failures

### DIFF
--- a/src/uv_ip.c
+++ b/src/uv_ip.c
@@ -56,11 +56,10 @@ int uvIpAddrSplit(const char *address,
 /* Synchronoues resolve hostname to IP address */
 int uvIpResolveBindAddresses(const char *address, struct addrinfo **ai_result)
 {
-    static struct addrinfo hints = {
-        .ai_flags = AI_ADDRCONFIG | AI_PASSIVE | AI_NUMERICSERV,
-        .ai_family = AF_INET,
-        .ai_socktype = SOCK_STREAM,
-        .ai_protocol = 0};
+    static struct addrinfo hints = {.ai_flags = AI_PASSIVE | AI_NUMERICSERV,
+                                    .ai_family = AF_INET,
+                                    .ai_socktype = SOCK_STREAM,
+                                    .ai_protocol = 0};
     char hostname[NI_MAXHOST];
     char service[NI_MAXSERV];
     int rv;

--- a/src/uv_tcp_connect.c
+++ b/src/uv_tcp_connect.c
@@ -215,9 +215,9 @@ static void uvTcpAsyncConnect(struct uvTcpConnect *connect)
 }
 
 /* The hostname resolve is finished */
-static void uvGetAddrInfoCb(uv_getaddrinfo_t *req,
-                            int status,
-                            struct addrinfo *res)
+static void uvTcpConnectGetAddrInfoCb(uv_getaddrinfo_t *req,
+                                      int status,
+                                      struct addrinfo *res)
 {
     struct uvTcpConnect *connect = req->data;
     struct UvTcp *t = connect->t;
@@ -285,8 +285,8 @@ static int uvTcpConnectStart(struct uvTcpConnect *r, const char *address)
         rv = RAFT_NOCONNECTION;
         goto err_after_tcp_init;
     }
-    rv = uv_getaddrinfo(r->t->loop, &r->getaddrinfo, &uvGetAddrInfoCb, hostname,
-                        service, &hints);
+    rv = uv_getaddrinfo(r->t->loop, &r->getaddrinfo, &uvTcpConnectGetAddrInfoCb,
+                        hostname, service, &hints);
     if (rv) {
         ErrMsgPrintf(t->transport->errmsg,
                      "uv_tcp_connect(): Cannot initiate getaddrinfo %s",

--- a/src/uv_tcp_connect.c
+++ b/src/uv_tcp_connect.c
@@ -243,14 +243,15 @@ static void uvTcpConnectGetAddrInfoCb(uv_getaddrinfo_t *req,
     connect->ai_current = res;
     uvTcpAsyncConnect(connect);
 }
+
 /* Create a new TCP handle and submit a connection request to the event loop. */
 static int uvTcpConnectStart(struct uvTcpConnect *r, const char *address)
 {
-    static struct addrinfo hints = {.ai_flags = AI_V4MAPPED | AI_ADDRCONFIG,
-                                    .ai_family = AF_INET,
-                                    .ai_socktype = SOCK_STREAM,
-                                    .ai_protocol = 0};
     struct UvTcp *t = r->t;
+    static struct addrinfo hints = {.ai_family = AF_INET,
+                                    .ai_socktype = SOCK_STREAM,
+                                    .ai_protocol = 0,
+                                    .ai_flags = 0};
     char hostname[NI_MAXHOST];
     char service[NI_MAXSERV];
     int rv;


### PR DESCRIPTION
Tests where failing when running them on a system without a non-loopback network interface configured with IPv4.