### PR TITLE
github: Point downstream workflow jobs to cowsql

### DIFF
--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -5,7 +5,7 @@ on:
     types: [created, edited]
 
 jobs:
-  dqlite:
+  cowsql:
     if: ${{ github.event.issue.pull_request && contains(github.event.comment.body, 'please test downstream') }}
     runs-on: ubuntu-22.04
     steps:
@@ -42,15 +42,15 @@ jobs:
           sudo make -j$(nproc) install
           sudo ldconfig
 
-      - name: Check out dqlite
+      - name: Check out cowsql
         uses: actions/checkout@v3
         with:
-          repository: canonical/dqlite 
-          path: dqlite
+          repository: cowsql/cowsql
+          path: cowsql
 
-      - name: Test and install dqlite
+      - name: Test and install cowsql
         run: |
-          cd dqlite
+          cd cowsql
           autoreconf -i
           ./configure --enable-debug --enable-sanitize --enable-backtrace
           sudo make -j$(nproc) check || (cat ./test-suite.log && false)
@@ -60,29 +60,26 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v4
 
-      - name: Check out go-dqlite
+      - name: Check out go-cowsql
         uses: actions/checkout@v3
         with:
-          repository: canonical/go-dqlite
+          repository: cowsql/go-cowsql
           path: go-dqlite
 
-      - name: Test go-dqlite
+      - name: Test go-cowsql
         env:
           GO_DQLITE_MULTITHREAD: '1'
         run: |
-          cd go-dqlite
+          cd go-cowsql
           go get -tags libsqlite3 -t ./...
           go test -asan -v ./...
           VERBOSE=1 ASAN=-asan ./test/dqlite-demo.sh
-          VERBOSE=1 ASAN=-asan DISK=1 ./test/dqlite-demo.sh
           VERBOSE=1 ASAN=-asan ./test/roles.sh
-          VERBOSE=1 ASAN=-asan DISK=1 ./test/roles.sh
           VERBOSE=1 ASAN=-asan ./test/recover.sh
-          VERBOSE=1 ASAN=-asan DISK=1 ./test/recover.sh
 
   jepsen:
     if: ${{ github.event.issue.pull_request && contains(github.event.comment.body, 'please test downstream') }}
-    uses: canonical/jepsen.dqlite/.github/workflows/test-build-run.yml@master
+    uses: cowsql/jepsen.cowsql/.github/workflows/test-build-run.yml@main
     with:
       raft-ref: refs/pull/${{ github.event.issue.number }}/head
       workloads: >


### PR DESCRIPTION
They were still referencing dqlite.
