### PR TITLE
replication: Update r->commit index immediately

### DIFF
--- a/include/raft.h
+++ b/include/raft.h
@@ -592,7 +592,6 @@ struct raft_persist_entries
     raft_index index;
     struct raft_entry *entries;
     unsigned n;
-    raft_index leader_commit;
 };
 
 /**

--- a/src/replication.c
+++ b/src/replication.c
@@ -36,7 +36,7 @@
  * message.
  *
  * TODO: Make this number configurable. */
-#define MAX_APPEND_ENTRIES 128
+#define MAX_APPEND_ENTRIES 32
 
 /* Context of a RAFT_IO_APPEND_ENTRIES request that was submitted with
  * raft_io_>send(). */

--- a/src/task.c
+++ b/src/task.c
@@ -63,8 +63,7 @@ err:
 int TaskPersistEntries(struct raft *r,
                        raft_index index,
                        struct raft_entry entries[],
-                       unsigned n,
-                       raft_index leader_commit)
+                       unsigned n)
 {
     struct raft_task *task;
     struct raft_persist_entries *params;
@@ -82,7 +81,6 @@ int TaskPersistEntries(struct raft *r,
     params->index = index;
     params->entries = entries;
     params->n = n;
-    params->leader_commit = leader_commit;
 
     return 0;
 

--- a/src/task.h
+++ b/src/task.h
@@ -29,8 +29,7 @@ int TaskSendMessage(struct raft *r,
 int TaskPersistEntries(struct raft *r,
                        raft_index first_index,
                        struct raft_entry entries[],
-                       unsigned n,
-                       raft_index leader_commit);
+                       unsigned n);
 
 /* Create and enqueue a RAFT_PERSIST_TERM_AND_VOTE task to persist the given
  * term and vote.


### PR DESCRIPTION
Don't lag r->commit_index unnecessarily. It is now updated immediately in a single place, i.e. in replicationAppend(), which is called when receiving an AppendEntries message.

Before that change it was updated immediately only if the AppendEntries message was empty, while if the AppendEntries message was not empty, it would instead be updated asynchronously after the raft_io>append_entries() request completes and its callback is fired.
