### PR TITLE
Use a task to restore snapshots at startup

### DIFF
--- a/include/raft.h
+++ b/include/raft.h
@@ -822,16 +822,21 @@ struct raft_log;
     }
 
 /* Extended struct raft fields added after the v0.x ABI freeze. */
-#define RAFT__EXTENSIONS                                                     \
-    struct                                                                   \
-    {                                                                        \
-        raft_time now;           /* Current time, updated via raft_step() */ \
-        unsigned random;         /* Pseudo-random number generator state */  \
-        struct raft_task *tasks; /* Queue of pending raft_task operations */ \
-        unsigned n_tasks;        /* Length of the task queue */              \
-        unsigned n_tasks_cap;    /* Capacity of the task queue */            \
-        /* Index of the last snapshot that was taken */                      \
-        raft_index configuration_last_snapshot_index;                        \
+#define RAFT__EXTENSIONS                                                       \
+    struct                                                                     \
+    {                                                                          \
+        raft_time now;           /* Current time, updated via raft_step() */   \
+        unsigned random;         /* Pseudo-random number generator state */    \
+        struct raft_task *tasks; /* Queue of pending raft_task operations */   \
+        unsigned n_tasks;        /* Length of the task queue */                \
+        unsigned n_tasks_cap;    /* Capacity of the task queue */              \
+        /* Index of the last snapshot that was taken */                        \
+        raft_index configuration_last_snapshot_index;                          \
+        /* Cache of the data of last snapshot that was persisted or loaded     \
+         * from disk at startup. This is necessary in order to execute         \
+         * TaskRestoreSnapshot tasks synchronously, since legacy raft_io-based \
+         * expects that. */                                                    \
+        struct raft_buffer io_snapshot_restore;                                \
     }
 
 RAFT__ASSERT_COMPATIBILITY(RAFT__RESERVED, RAFT__EXTENSIONS);

--- a/src/raft.c
+++ b/src/raft.c
@@ -109,6 +109,8 @@ int raft_init(struct raft *r,
     r->tasks = NULL;
     r->n_tasks = 0;
     r->n_tasks_cap = 0;
+    r->io_snapshot_restore.base = NULL;
+    r->io_snapshot_restore.len = 0;
     return 0;
 
 err_after_address_alloc:


### PR DESCRIPTION
Improve the legacy compatibility code to properly handle `struct raft_restore_snapshot` tasks and execute them synchronously, as current client code expects, and then use `TaskRestoreSnasphot()` to restore snapshots at startup, instead of `struct raft_fsm->restore()`.