### PR TITLE
Release 0.18.1

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ(2.60)
-AC_INIT([raft], [0.17.7])
+AC_INIT([raft], [0.18.1])
 AC_LANG([C])
 AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_AUX_DIR([ac])


### PR DESCRIPTION
Use a greater version than canonical/raft, making updates easier for distributions that have already packaged 0.18.0.