### PR TITLE
Allow passing NULL io and fsm to raft_init()

### DIFF
--- a/src/raft.c
+++ b/src/raft.c
@@ -63,6 +63,7 @@ int raft_init(struct raft *r,
     /* Make a copy of the address */
     r->address = RaftHeapMalloc(strlen(address) + 1);
     if (r->address == NULL) {
+        ErrMsgOom(r->errmsg);
         rv = RAFT_NOMEM;
         goto err;
     }
@@ -71,6 +72,7 @@ int raft_init(struct raft *r,
     r->voted_for = 0;
     r->log = logInit();
     if (r->log == NULL) {
+        ErrMsgOom(r->errmsg);
         rv = RAFT_NOMEM;
         goto err_after_address_alloc;
     }

--- a/src/raft.c
+++ b/src/raft.c
@@ -54,7 +54,6 @@ int raft_init(struct raft *r,
     }
 
     r->io = io;
-    r->io->data = r;
     r->fsm = fsm;
 
     r->tracer = &StderrTracer;
@@ -99,13 +98,16 @@ int raft_init(struct raft *r,
     r->max_catch_up_rounds = DEFAULT_MAX_CATCH_UP_ROUNDS;
     r->max_catch_up_round_duration = DEFAULT_MAX_CATCH_UP_ROUND_DURATION;
     r->now = 0;
-    rv = r->io->init(r->io, r->id, r->address);
-    if (rv != 0) {
-        ErrMsgTransfer(r->io->errmsg, r->errmsg, "io");
-        goto err_after_address_alloc;
+    if (io != NULL) {
+        r->io->data = r;
+        rv = r->io->init(r->io, r->id, r->address);
+        if (rv != 0) {
+            ErrMsgTransfer(r->io->errmsg, r->errmsg, "io");
+            goto err_after_address_alloc;
+        }
+        r->now = r->io->time(r->io);
+        raft_seed(r, (unsigned)r->io->random(r->io, 0, INT_MAX));
     }
-    r->now = r->io->time(r->io);
-    raft_seed(r, (unsigned)r->io->random(r->io, 0, INT_MAX));
     r->tasks = NULL;
     r->n_tasks = 0;
     r->n_tasks_cap = 0;
@@ -120,10 +122,8 @@ err:
     return rv;
 }
 
-static void ioCloseCb(struct raft_io *io)
+static void finalClose(struct raft *r)
 {
-    struct raft *r = io->data;
-    tracef("io close cb");
     raft_free(r->address);
     logClose(r->log);
     raft_configuration_close(&r->configuration);
@@ -131,6 +131,12 @@ static void ioCloseCb(struct raft_io *io)
     if (r->tasks != NULL) {
         raft_free(r->tasks);
     }
+}
+
+static void ioCloseCb(struct raft_io *io)
+{
+    struct raft *r = io->data;
+    finalClose(r);
     if (r->close_cb != NULL) {
         r->close_cb(r);
     }
@@ -143,7 +149,11 @@ void raft_close(struct raft *r, void (*cb)(struct raft *r))
         convertToUnavailable(r);
     }
     r->close_cb = cb;
-    r->io->close(r->io, ioCloseCb);
+    if (r->io != NULL) {
+        r->io->close(r->io, ioCloseCb);
+    } else {
+        finalClose(r);
+    }
 }
 
 void raft_seed(struct raft *r, unsigned random)
@@ -423,6 +433,10 @@ static int ioFsmVersionCheck(struct raft *r,
                              struct raft_io *io,
                              struct raft_fsm *fsm)
 {
+    if (io == NULL && fsm == NULL) {
+        return 0;
+    }
+
     if (io->version == 0) {
         ErrMsgPrintf(r->errmsg, "io->version must be set");
         return -1;

--- a/src/raft.c
+++ b/src/raft.c
@@ -239,7 +239,7 @@ static int stepDone(struct raft *r, struct raft_task *task, int status)
             rv = applyCommandDone(r, task, status);
             break;
         default:
-            rv = 0;
+            rv = RAFT_INVALID;
             break;
     }
 

--- a/test/integration/test_init.c
+++ b/test/integration/test_init.c
@@ -1,5 +1,32 @@
 #include "../../include/raft.h"
+#include "../lib/heap.h"
 #include "../lib/runner.h"
+
+/******************************************************************************
+ *
+ * Fixture holding an unitialized raft object.
+ *
+ *****************************************************************************/
+
+struct fixture
+{
+    FIXTURE_HEAP;
+    struct raft raft;
+};
+
+static void *setUp(const MunitParameter params[], MUNIT_UNUSED void *user_data)
+{
+    struct fixture *f = munit_malloc(sizeof *f);
+    SET_UP_HEAP;
+    return f;
+}
+
+static void tearDown(void *data)
+{
+    struct fixture *f = data;
+    TEAR_DOWN_HEAP;
+    free(f);
+}
 
 /******************************************************************************
  *
@@ -36,5 +63,16 @@ TEST(raft_init, fsmVersionNotSet, NULL, NULL, 0, NULL)
     rc = raft_init(&r, &io, &fsm, 1, "1");
     munit_assert_int(rc, ==, -1);
     munit_assert_string_equal(r.errmsg, "fsm->version must be set");
+    return MUNIT_OK;
+}
+
+/* The io and fsm objects can be set to NULL */
+TEST(raft_init, nullFsmAndIo, setUp, tearDown, 0, NULL)
+{
+    struct fixture *f = data;
+    int rv;
+    rv = raft_init(&f->raft, NULL, NULL, 1, "1");
+    munit_assert_int(rv, ==, 0);
+    raft_close(&f->raft, NULL);
     return MUNIT_OK;
 }

--- a/test/integration/test_init.c
+++ b/test/integration/test_init.c
@@ -76,3 +76,24 @@ TEST(raft_init, nullFsmAndIo, setUp, tearDown, 0, NULL)
     raft_close(&f->raft, NULL);
     return MUNIT_OK;
 }
+
+static char *oom_heap_fault_delay[] = {"0", "1", NULL};
+static char *oom_heap_fault_repeat[] = {"1", NULL};
+
+static MunitParameterEnum oom_params[] = {
+    {TEST_HEAP_FAULT_DELAY, oom_heap_fault_delay},
+    {TEST_HEAP_FAULT_REPEAT, oom_heap_fault_repeat},
+    {NULL, NULL},
+};
+
+/* Out of memory failures. */
+TEST(raft_init, oom, setUp, tearDown, 0, oom_params)
+{
+    struct fixture *f = data;
+    int rv;
+    HEAP_FAULT_ENABLE;
+    rv = raft_init(&f->raft, NULL, NULL, 1, "1");
+    munit_assert_int(rv, ==, RAFT_NOMEM);
+    munit_assert_string_equal(raft_errmsg(&f->raft), "out of memory");
+    return MUNIT_OK;
+}


### PR DESCRIPTION
In v1 there will be no need to pass raft_io and raft_fsm objects to raft_init(), this branch is a step in that direction.