### PR TITLE
v1: Use flags to keep track of pending snapshots

### DIFF
--- a/include/raft.h
+++ b/include/raft.h
@@ -837,16 +837,18 @@ struct raft_log;
 
 RAFT__ASSERT_COMPATIBILITY(RAFT__RESERVED, RAFT__EXTENSIONS);
 
-#define RAFT__SNAPSHOT_FIELDS_V0       \
-    struct                             \
-    {                                  \
-        struct raft_snapshot _pending; \
+#define RAFT__SNAPSHOT_FIELDS_V0          \
+    struct                                \
+    {                                     \
+        struct raft_snapshot _pending;    \
+        struct raft_io_snapshot_put _put; \
     }
 
-#define RAFT__SNAPSHOT_FIELDS_V1                                             \
-    struct                                                                   \
-    {                                                                        \
-        bool taking; /* True if a RAFT_TAKE_SNAPSHOT request is in flight */ \
+#define RAFT__SNAPSHOT_FIELDS_V1                                           \
+    struct                                                                 \
+    {                                                                      \
+        bool taking;     /* A RAFT_TAKE_SNAPSHOT request is in flight */   \
+        bool persisting; /* A RAFT_PERSIT_SNAPSHOT request is in flight */ \
     }
 
 RAFT__ASSERT_COMPATIBILITY(RAFT__SNAPSHOT_FIELDS_V0, RAFT__SNAPSHOT_FIELDS_V1);
@@ -1040,8 +1042,7 @@ struct raft
             RAFT__SNAPSHOT_FIELDS_V0;
             RAFT__SNAPSHOT_FIELDS_V1;
         };
-        struct raft_io_snapshot_put put; /* Store snapshot request */
-        uint64_t reserved[8];            /* Future use */
+        uint64_t reserved[8]; /* Future use */
     } snapshot;
 
     /*

--- a/include/raft.h
+++ b/include/raft.h
@@ -837,6 +837,20 @@ struct raft_log;
 
 RAFT__ASSERT_COMPATIBILITY(RAFT__RESERVED, RAFT__EXTENSIONS);
 
+#define RAFT__SNAPSHOT_FIELDS_V0       \
+    struct                             \
+    {                                  \
+        struct raft_snapshot _pending; \
+    }
+
+#define RAFT__SNAPSHOT_FIELDS_V1                                             \
+    struct                                                                   \
+    {                                                                        \
+        bool taking; /* True if a RAFT_TAKE_SNAPSHOT request is in flight */ \
+    }
+
+RAFT__ASSERT_COMPATIBILITY(RAFT__SNAPSHOT_FIELDS_V0, RAFT__SNAPSHOT_FIELDS_V1);
+
 /**
  * Hold and drive the state of a single raft server in a cluster.
  * When replacing reserved fields in the middle of this struct, you MUST use a
@@ -1020,9 +1034,12 @@ struct raft
      */
     struct
     {
-        unsigned threshold;              /* N. of entries before snapshot */
-        unsigned trailing;               /* N. of trailing entries to retain */
-        struct raft_snapshot pending;    /* In progress snapshot */
+        unsigned threshold; /* N. of entries before snapshot */
+        unsigned trailing;  /* N. of trailing entries to retain */
+        union {
+            RAFT__SNAPSHOT_FIELDS_V0;
+            RAFT__SNAPSHOT_FIELDS_V1;
+        };
         struct raft_io_snapshot_put put; /* Store snapshot request */
         uint64_t reserved[8];            /* Future use */
     } snapshot;
@@ -1056,6 +1073,9 @@ struct raft
 
 #undef RAFT__RESERVED
 #undef RAFT__EXTENSIONS
+
+#undef RAFT__SNAPSHOT_FIELDS_V1
+#undef RAFT__SNAPSHOT_FIELDS_V2
 
 RAFT_API int raft_init(struct raft *r,
                        struct raft_io *io,

--- a/src/raft.c
+++ b/src/raft.c
@@ -93,7 +93,7 @@ int raft_init(struct raft *r,
     r->snapshot.threshold = DEFAULT_SNAPSHOT_THRESHOLD;
     r->snapshot.trailing = DEFAULT_SNAPSHOT_TRAILING;
     r->snapshot.taking = false;
-    r->snapshot.put.data = NULL;
+    r->snapshot.persisting = false;
     r->close_cb = NULL;
     memset(r->errmsg, 0, sizeof r->errmsg);
     r->pre_vote = false;

--- a/src/raft.c
+++ b/src/raft.c
@@ -90,9 +90,9 @@ int raft_init(struct raft *r,
     r->last_stored = 0;
     r->state = RAFT_UNAVAILABLE;
     r->transfer = NULL;
-    r->snapshot.pending.term = 0;
     r->snapshot.threshold = DEFAULT_SNAPSHOT_THRESHOLD;
     r->snapshot.trailing = DEFAULT_SNAPSHOT_TRAILING;
+    r->snapshot.taking = false;
     r->snapshot.put.data = NULL;
     r->close_cb = NULL;
     memset(r->errmsg, 0, sizeof r->errmsg);

--- a/src/replication.c
+++ b/src/replication.c
@@ -1287,7 +1287,7 @@ int replicationInstallSnapshot(struct raft *r,
     /* If we are taking a snapshot ourselves or installing a snapshot, ignore
      * the request, the leader will eventually retry. TODO: we should do
      * something smarter. */
-    if (r->snapshot.pending.term != 0 || r->snapshot.put.data != NULL) {
+    if (r->snapshot.taking || r->snapshot.put.data != NULL) {
         *async = true;
         tracef("already taking or installing snapshot");
         return RAFT_BUSY;


### PR DESCRIPTION
Instead of indirectly detect pending snapshot by looking at the `struct raft->snapshot.pending` and `struct raft->snapshot.put` fields, use explicit flags.

This is an incremental step towards having snapshots entirely driven by client code. 