### PR TITLE
v1: Change snapshotRestore() to take metadata instead of snapshot

### DIFF
--- a/src/snapshot.c
+++ b/src/snapshot.c
@@ -27,15 +27,13 @@ void snapshotDestroy(struct raft_snapshot *s)
     raft_free(s);
 }
 
-int snapshotRestore(struct raft *r, struct raft_snapshot *snapshot)
+int snapshotRestore(struct raft *r, struct raft_snapshot_metadata *metadata)
 {
     int rv;
 
-    assert(snapshot->n_bufs == 1);
-
     configurationClose(&r->configuration);
-    r->configuration = snapshot->configuration;
-    r->configuration_committed_index = snapshot->configuration_index;
+    r->configuration = metadata->configuration;
+    r->configuration_committed_index = metadata->configuration_index;
     r->configuration_uncommitted_index = 0;
 
     /* Make a copy of the configuration contained in the snapshot, in case
@@ -50,14 +48,14 @@ int snapshotRestore(struct raft *r, struct raft_snapshot *snapshot)
 
     /* Make also a copy of the index of the configuration contained in the
      * snapshot, we'll need it in case we send out an InstallSnapshot RPC. */
-    r->configuration_last_snapshot_index = snapshot->configuration_index;
+    r->configuration_last_snapshot_index = metadata->configuration_index;
 
     configurationTrace(r, &r->configuration,
                        "configuration restore from snapshot");
 
-    r->commit_index = snapshot->index;
-    r->last_applied = snapshot->index;
-    r->last_stored = snapshot->index;
+    r->commit_index = metadata->index;
+    r->last_applied = metadata->index;
+    r->last_stored = metadata->index;
 
     return 0;
 }

--- a/src/snapshot.h
+++ b/src/snapshot.h
@@ -11,13 +11,12 @@ void snapshotDestroy(struct raft_snapshot *s);
 
 /* Restore a snapshot.
  *
- * This will reset the current state of the server as if the last entry
- * contained in the snapshot had just been persisted, committed and applied.
+ * This will reset the current state of the raft object as if the last entry
+ * contained in the snapshot with the given metadata had just been persisted,
+ * committed and applied.
  *
- * The in-memory log must be empty when calling this function.
- *
- * If no error occurs, the memory of the snapshot object gets released. */
-int snapshotRestore(struct raft *r, struct raft_snapshot *snapshot);
+ * The in-memory log must be empty when calling this function. */
+int snapshotRestore(struct raft *r, struct raft_snapshot_metadata *metadata);
 
 /* Make a full deep copy of a snapshot object.
  *

--- a/src/start.c
+++ b/src/start.c
@@ -139,6 +139,7 @@ static int maybeSelfElect(struct raft *r)
 int raft_start(struct raft *r)
 {
     struct raft_snapshot *snapshot;
+    struct raft_snapshot_metadata metadata;
     raft_index snapshot_index = 0;
     raft_term snapshot_term = 0;
     raft_index start_index;
@@ -187,7 +188,11 @@ int raft_start(struct raft *r)
             return rv;
         }
 
-        rv = snapshotRestore(r, snapshot);
+        metadata.index = snapshot->index;
+        metadata.term = snapshot->term;
+        metadata.configuration = snapshot->configuration;
+        metadata.configuration_index = snapshot->configuration_index;
+        rv = snapshotRestore(r, &metadata);
         if (rv != 0) {
             entryBatchesDestroy(entries, n_entries);
             return rv;


### PR DESCRIPTION
The snapshotRestore() does not need a full snapshot object, and instead it now uses just the matadata.