### PR TITLE
Drop unnecessary tasks

### DIFF
--- a/include/raft.h
+++ b/include/raft.h
@@ -818,21 +818,16 @@ struct raft_log;
     }
 
 /* Extended struct raft fields added after the v0.x ABI freeze. */
-#define RAFT__EXTENSIONS                                                       \
-    struct                                                                     \
-    {                                                                          \
-        raft_time now;           /* Current time, updated via raft_step() */   \
-        unsigned random;         /* Pseudo-random number generator state */    \
-        struct raft_task *tasks; /* Queue of pending raft_task operations */   \
-        unsigned n_tasks;        /* Length of the task queue */                \
-        unsigned n_tasks_cap;    /* Capacity of the task queue */              \
-        /* Index of the last snapshot that was taken */                        \
-        raft_index configuration_last_snapshot_index;                          \
-        /* Cache of the data of last snapshot that was persisted or loaded     \
-         * from disk at startup. This is necessary in order to execute         \
-         * TaskRestoreSnapshot tasks synchronously, since legacy raft_io-based \
-         * expects that. */                                                    \
-        struct raft_buffer io_snapshot_restore;                                \
+#define RAFT__EXTENSIONS                                                     \
+    struct                                                                   \
+    {                                                                        \
+        raft_time now;           /* Current time, updated via raft_step() */ \
+        unsigned random;         /* Pseudo-random number generator state */  \
+        struct raft_task *tasks; /* Queue of pending raft_task operations */ \
+        unsigned n_tasks;        /* Length of the task queue */              \
+        unsigned n_tasks_cap;    /* Capacity of the task queue */            \
+        /* Index of the last snapshot that was taken */                      \
+        raft_index configuration_last_snapshot_index;                        \
     }
 
 RAFT__ASSERT_COMPATIBILITY(RAFT__RESERVED, RAFT__EXTENSIONS);

--- a/include/raft.h
+++ b/include/raft.h
@@ -566,7 +566,6 @@ enum {
     RAFT_PERSIST_TERM_AND_VOTE,
     RAFT_PERSIST_SNAPSHOT,
     RAFT_LOAD_SNAPSHOT,
-    RAFT_APPLY_COMMAND,
 };
 
 /**
@@ -624,16 +623,6 @@ struct raft_persist_snapshot
 };
 
 /**
- * Parameters fork tasks of type #RAFT_APPLY_COMMAND.
- */
-struct raft_apply_command
-{
-    raft_index index;
-    const struct raft_buffer *command;
-    void *result; /* TODO: drop this field */
-};
-
-/**
  * Represents a task that can be queued and executed asynchronously.
  */
 struct raft_task
@@ -646,7 +635,6 @@ struct raft_task
         struct raft_load_snapshot load_snapshot;
         struct raft_persist_entries persist_entries;
         struct raft_persist_snapshot persist_snapshot;
-        struct raft_apply_command apply_command;
     };
 };
 

--- a/include/raft.h
+++ b/include/raft.h
@@ -567,7 +567,6 @@ enum {
     RAFT_PERSIST_SNAPSHOT,
     RAFT_LOAD_SNAPSHOT,
     RAFT_APPLY_COMMAND,
-    RAFT_RESTORE_SNAPSHOT
 };
 
 /**
@@ -635,14 +634,6 @@ struct raft_apply_command
 };
 
 /**
- * Parameters for tasks of type #RAFT_RESTORE_SNAPSHOT.
- */
-struct raft_restore_snapshot
-{
-    raft_index index;
-};
-
-/**
  * Represents a task that can be queued and executed asynchronously.
  */
 struct raft_task
@@ -656,7 +647,6 @@ struct raft_task
         struct raft_persist_entries persist_entries;
         struct raft_persist_snapshot persist_snapshot;
         struct raft_apply_command apply_command;
-        struct raft_restore_snapshot restore_snapshot;
     };
 };
 

--- a/src/legacy.c
+++ b/src/legacy.c
@@ -286,37 +286,6 @@ static int ioForwardLoadSnapshot(struct raft *r, struct raft_task *task)
     return 0;
 }
 
-static int ioForwardApplyCommand(struct raft *r,
-                                 struct raft_task *task,
-                                 struct raft_event *events[],
-                                 unsigned *n_events)
-{
-    struct raft_apply_command *params = &task->apply_command;
-    struct raft_event *event;
-    int rv;
-    rv = r->fsm->apply(r->fsm, params->command, &params->result);
-    if (rv != 0) {
-        return rv;
-    }
-
-    /* Add a completion event immediately, since fsm->apply() is required to be
-     * synchronous */
-    event = eventAppend(events, n_events);
-    if (event == NULL) {
-        rv = RAFT_NOMEM;
-        goto err;
-    }
-
-    event->type = RAFT_DONE;
-    event->time = r->io->time(r->io);
-    event->done.task = *task;
-    event->done.status = 0;
-
-    return 0;
-err:
-    return rv;
-}
-
 struct legacyTakeSnapshot
 {
     struct raft *r;
@@ -550,9 +519,6 @@ int LegacyForwardToRaftIo(struct raft *r, struct raft_event *event)
                     break;
                 case RAFT_LOAD_SNAPSHOT:
                     rv = ioForwardLoadSnapshot(r, task);
-                    break;
-                case RAFT_APPLY_COMMAND:
-                    rv = ioForwardApplyCommand(r, task, &events, &n_events);
                     break;
                 default:
                     rv = RAFT_INVALID;

--- a/src/raft.c
+++ b/src/raft.c
@@ -202,12 +202,6 @@ static int persistSnapshotDone(struct raft *r,
     return replicationPersistSnapshotDone(r, params, status);
 }
 
-static int applyCommandDone(struct raft *r, struct raft_task *task, int status)
-{
-    struct raft_apply_command *params = &task->apply_command;
-    return replicationApplyCommandDone(r, params, status);
-}
-
 /* Handle the completion of a task. */
 static int stepDone(struct raft *r, struct raft_task *task, int status)
 {
@@ -234,9 +228,6 @@ static int stepDone(struct raft *r, struct raft_task *task, int status)
             break;
         case RAFT_LOAD_SNAPSHOT:
             rv = loadSnapshotDone(r, task, status);
-            break;
-        case RAFT_APPLY_COMMAND:
-            rv = applyCommandDone(r, task, status);
             break;
         default:
             rv = RAFT_INVALID;

--- a/src/raft.c
+++ b/src/raft.c
@@ -113,8 +113,6 @@ int raft_init(struct raft *r,
     r->tasks = NULL;
     r->n_tasks = 0;
     r->n_tasks_cap = 0;
-    r->io_snapshot_restore.base = NULL;
-    r->io_snapshot_restore.len = 0;
     return 0;
 
 err_after_address_alloc:

--- a/src/replication.c
+++ b/src/replication.c
@@ -1204,21 +1204,13 @@ int replicationPersistSnapshotDone(struct raft *r,
         goto discard;
     }
 
-    if (r->io != NULL) {
-        /* Save the snapshot data in the cache, it will be used by legacy compat
-         * code to avoid loading the snapshot asynchronously. */
-        assert(r->io_snapshot_restore.base == NULL);
-        assert(r->io_snapshot_restore.len == 0);
-        r->io_snapshot_restore = params->chunk;
-    }
-
     /* From Figure 5.3:
      *
      *   7. Discard the entire log
      *   8. Reset state machine using snapshot contents (and load lastConfig
      *      as cluster configuration).
      */
-    rv = TaskRestoreSnapshot(r, params->metadata.index);
+    rv = r->fsm->restore(r->fsm, &params->chunk);
     if (rv != 0) {
         tracef("restore snapshot %llu: %s", params->metadata.index,
                errCodeToString(rv));

--- a/src/replication.c
+++ b/src/replication.c
@@ -1312,24 +1312,6 @@ err:
     return rv;
 }
 
-int replicationApplyCommandDone(struct raft *r,
-                                struct raft_apply_command *params,
-                                int status)
-{
-    struct raft_apply *req;
-
-    if (status != 0) {
-        return status;
-    }
-
-    req = (struct raft_apply *)getRequest(r, params->index, RAFT_COMMAND);
-    if (req != NULL && req->cb != NULL) {
-        req->cb(req, 0, params->result);
-    }
-
-    return 0;
-}
-
 /* Apply a RAFT_COMMAND entry that has been committed. */
 static int applyCommand(struct raft *r,
                         const raft_index index,

--- a/src/replication.h
+++ b/src/replication.h
@@ -122,11 +122,6 @@ int replicationPersistSnapshotDone(struct raft *r,
                                    struct raft_persist_snapshot *params,
                                    int status);
 
-/* Called when a RAFT_APPLY_COMMAND task has been completed. */
-int replicationApplyCommandDone(struct raft *r,
-                                struct raft_apply_command *params,
-                                int status);
-
 /* Called when a RAFT_SNAPSHOT event is fired, signalling the completion of a
  * new snapshot. */
 int replicationSnapshot(struct raft *r,

--- a/src/restore.c
+++ b/src/restore.c
@@ -205,11 +205,7 @@ int raft_start(struct raft *r)
 
         /* Save the snapshot data in the cache, it will be used by legacy compat
          * code to avoid loading the snapshot asynchronously. */
-        assert(r->io_snapshot_restore.base == NULL);
-        assert(r->io_snapshot_restore.len == 0);
-        r->io_snapshot_restore = snapshot->bufs[0];
-
-        rv = TaskRestoreSnapshot(r, snapshot->index);
+        rv = r->fsm->restore(r->fsm, &snapshot->bufs[0]);
         if (rv != 0) {
             tracef("restore snapshot %llu: %s", snapshot->index,
                    errCodeToString(rv));

--- a/src/task.c
+++ b/src/task.c
@@ -196,27 +196,3 @@ err:
     assert(rv == RAFT_NOMEM);
     return rv;
 }
-
-int TaskRestoreSnapshot(struct raft *r, raft_index index)
-{
-    struct raft_task *task;
-    struct raft_restore_snapshot *params;
-    int rv;
-
-    task = taskAppend(r);
-    if (task == NULL) {
-        rv = RAFT_NOMEM;
-        goto err;
-    }
-
-    task->type = RAFT_RESTORE_SNAPSHOT;
-
-    params = &task->restore_snapshot;
-    params->index = index;
-
-    return 0;
-
-err:
-    assert(rv == RAFT_NOMEM);
-    return rv;
-}

--- a/src/task.c
+++ b/src/task.c
@@ -169,30 +169,3 @@ err:
     assert(rv == RAFT_NOMEM);
     return rv;
 }
-
-int TaskApplyCommand(struct raft *r,
-                     raft_index index,
-                     const struct raft_buffer *command)
-{
-    struct raft_task *task;
-    struct raft_apply_command *params;
-    int rv;
-
-    task = taskAppend(r);
-    if (task == NULL) {
-        rv = RAFT_NOMEM;
-        goto err;
-    }
-
-    task->type = RAFT_APPLY_COMMAND;
-
-    params = &task->apply_command;
-    params->index = index;
-    params->command = command;
-
-    return 0;
-
-err:
-    assert(rv == RAFT_NOMEM);
-    return rv;
-}

--- a/src/task.h
+++ b/src/task.h
@@ -65,16 +65,4 @@ int TaskPersistSnapshot(struct raft *r,
  */
 int TaskLoadSnapshot(struct raft *r, raft_index index, size_t offset);
 
-/* Create and enqueue a RAFT_APPLY_COMMAND task to apply to the application FSM
- * the given command, contained in the entry at the given index.
- *
- * Errors:
- *
- * RAFT_NOMEM
- *     The r->tasks array could not be resized to fit the new task.
- */
-int TaskApplyCommand(struct raft *r,
-                     raft_index index,
-                     const struct raft_buffer *command);
-
 #endif /* RAFT_TASK_H_ */

--- a/src/task.h
+++ b/src/task.h
@@ -77,14 +77,4 @@ int TaskApplyCommand(struct raft *r,
                      raft_index index,
                      const struct raft_buffer *command);
 
-/* Create and enqueue a RAFT_TAKE_SNAPSHOT task to reset the state of the
- * application FSM using the snapshot at the given index.
- *
- * Errors:
- *
- * RAFT_NOMEM
- *     The r->tasks array could not be resized to fit the new task.
- */
-int TaskRestoreSnapshot(struct raft *r, raft_index index);
-
 #endif /* RAFT_TASK_H_ */


### PR DESCRIPTION
The `struct raft_restore_snapshot` and `struct raft_apply_command` tasks are now unnecessary, since that logic is going to be performed entirely by consumer code.