### PR TITLE
Apply committed entries eagerly on followers

### DIFF
--- a/src/replication.c
+++ b/src/replication.c
@@ -1101,9 +1101,8 @@ int replicationAppend(struct raft *r,
      *   commitIndex, set commitIndex = min(leaderCommit, index of last new
      *   entry).
      */
-    if (args->leader_commit > r->commit_index &&
-        r->last_stored >= r->commit_index) {
-        r->commit_index = min(args->leader_commit, r->last_stored);
+    if (args->leader_commit > r->commit_index) {
+        r->commit_index = min(args->leader_commit, logLastIndex(r->log));
     }
 
     /* If this is an empty AppendEntries, there's nothing to write. However we

--- a/src/replication.c
+++ b/src/replication.c
@@ -1117,13 +1117,13 @@ int replicationAppend(struct raft *r,
      *   commitIndex, set commitIndex = min(leaderCommit, index of last new
      *   entry).
      */
-    if (n == 0) {
-        if (!replicationInstallSnapshotBusy(r)) {
-            rv = replicationApply(r);
-            if (rv != 0) {
-                return rv;
-            }
+    if (!replicationInstallSnapshotBusy(r)) {
+        rv = replicationApply(r);
+        if (rv != 0) {
+            return rv;
         }
+    }
+    if (n == 0) {
         return 0;
     }
 

--- a/test/integration/test_snapshot.c
+++ b/test/integration/test_snapshot.c
@@ -551,8 +551,13 @@ TEST(snapshot, installSnapshotDuringEntriesWrite, setUp, tearDown, 0, NULL)
     /* Set a large disk latency on the follower, this will allow a
      * InstallSnapshot RPC to arrive while the entries are being persisted. */
     CLUSTER_SET_DISK_LATENCY(1, 2000);
-    SET_SNAPSHOT_THRESHOLD(3);
-    SET_SNAPSHOT_TRAILING(1);
+
+    /* Set a low snapshot threshold on the leader (only do that on the leader,
+     * and not on the follower, otherwise the follower would trigger a snapshot
+     * and then receive the InstallSnapshot message while the snapshot is in
+     * progress, and would reject it. */
+    raft_set_snapshot_threshold(CLUSTER_RAFT(0), 3);
+    raft_set_snapshot_trailing(CLUSTER_RAFT(0), 1);
 
     /* Replicate some entries, these will take a while to persist */
     CLUSTER_MAKE_PROGRESS;


### PR DESCRIPTION
Don't make followers wait for entries to be persisted on disk before advancing their commit index.