### PR TITLE
Fire client callbacks after raft_step() has completed

### DIFF
--- a/include/raft.h
+++ b/include/raft.h
@@ -809,7 +809,8 @@ struct raft_log;
         /* Fields used by the v0 compatibility code */                       \
         struct                                                               \
         {                                                                    \
-            raft_index last_applied;                                         \
+            raft_index last_applied; /* Last index applied to raft_fsm */    \
+            void *requests[2];       /* Completed client requests */         \
         } legacy;                                                            \
     }
 
@@ -1231,10 +1232,11 @@ RAFT_API raft_index raft_last_applied(struct raft *r);
     }
 
 /* Extended RAFT__REQUEST fields added after the v0.x ABI freeze. */
-#define RAFT__REQUEST_EXTENSIONS                                        \
-    struct                                                              \
-    {                                                                   \
-        int status; /* Store the request result, for delayed firing. */ \
+#define RAFT__REQUEST_EXTENSIONS                                              \
+    struct                                                                    \
+    {                                                                         \
+        int status;   /* Store the request status code, for delayed firing */ \
+        void *result; /* For raft_apply, store the request result */          \
     }
 
 RAFT__ASSERT_COMPATIBILITY(RAFT__REQUEST_RESERVED, RAFT__REQUEST_EXTENSIONS);

--- a/include/raft.h
+++ b/include/raft.h
@@ -186,7 +186,8 @@ RAFT_API unsigned long long raft_digest(const char *text, unsigned long long n);
 enum {
     RAFT_COMMAND = 1, /* Command for the application FSM. */
     RAFT_BARRIER,     /* Wait for all previous commands to be applied. */
-    RAFT_CHANGE       /* Raft configuration change. */
+    RAFT_CHANGE,      /* Raft configuration change. */
+    RAFT_TRANSFER,    /* Raft leadership trasfer */
 };
 
 /**
@@ -647,7 +648,6 @@ enum {
     RAFT_SNAPSHOT, /* A snapshot has been taken. */
     RAFT_TIMEOUT,  /* The timeout has expired. */
     RAFT_SUBMIT,   /* New entries have been submitted. */
-    RAFT_TRANSFER, /* Submission of leadership trasfer request */
 };
 
 /**

--- a/include/raft.h
+++ b/include/raft.h
@@ -1223,21 +1223,41 @@ RAFT_API raft_index raft_last_index(struct raft *r);
  */
 RAFT_API raft_index raft_last_applied(struct raft *r);
 
+/* Unused uint64_t slots that are reserved for v0.x extensions.*/
+#define RAFT__REQUEST_RESERVED \
+    struct                     \
+    {                          \
+        uint64_t reserved[4];  \
+    }
+
+/* Extended RAFT__REQUEST fields added after the v0.x ABI freeze. */
+#define RAFT__REQUEST_EXTENSIONS                                        \
+    struct                                                              \
+    {                                                                   \
+        int status; /* Store the request result, for delayed firing. */ \
+    }
+
+RAFT__ASSERT_COMPATIBILITY(RAFT__REQUEST_RESERVED, RAFT__REQUEST_EXTENSIONS);
+
 /**
  * Common fields across client request types.
  * `req_id`, `client_id` and `unique_id` are currently unused.
  * `reserved` fields should be replaced by new members with the same size
  * and alignment requirements as `uint64_t`.
  */
-#define RAFT__REQUEST      \
-    void *data;            \
-    int type;              \
-    raft_index index;      \
-    void *queue[2];        \
-    uint8_t req_id[16];    \
-    uint8_t client_id[16]; \
-    uint8_t unique_id[16]; \
-    uint64_t reserved[4]
+#define RAFT__REQUEST                                                         \
+    void *data;                                                               \
+    int type;                                                                 \
+    raft_index index;                                                         \
+    void *queue[2];                                                           \
+    uint8_t req_id[16];                                                       \
+    uint8_t client_id[16];                                                    \
+    uint8_t unique_id[16];                                                    \
+    /* Fields added after the v0.x ABI freeze, packed in the unused space. */ \
+    union {                                                                   \
+        RAFT__REQUEST_RESERVED;                                               \
+        RAFT__REQUEST_EXTENSIONS;                                             \
+    }
 
 /**
  * Asynchronous request to append a new command entry to the log and apply it to

--- a/include/raft.h
+++ b/include/raft.h
@@ -806,6 +806,11 @@ struct raft_log;
         unsigned n_tasks_cap;    /* Capacity of the task queue */            \
         /* Index of the last snapshot that was taken */                      \
         raft_index configuration_last_snapshot_index;                        \
+        /* Fields used by the v0 compatibility code */                       \
+        struct                                                               \
+        {                                                                    \
+            raft_index last_applied;                                         \
+        } legacy;                                                            \
     }
 
 RAFT__ASSERT_COMPATIBILITY(RAFT__RESERVED, RAFT__EXTENSIONS);

--- a/src/legacy.c
+++ b/src/legacy.c
@@ -473,6 +473,11 @@ static void legacyFireChange(struct raft_change *req)
     req->cb(req, req->status);
 }
 
+static void legacyFireTransfer(struct raft_transfer *req)
+{
+    req->cb(req);
+}
+
 void LegacyFireCompletedRequests(struct raft *r)
 {
     while (!QUEUE_IS_EMPTY(&r->legacy.requests)) {
@@ -490,6 +495,9 @@ void LegacyFireCompletedRequests(struct raft *r)
                 break;
             case RAFT_CHANGE:
                 legacyFireChange((struct raft_change *)req);
+                break;
+            case RAFT_TRANSFER:
+                legacyFireTransfer((struct raft_transfer *)req);
                 break;
         };
     }

--- a/src/legacy.c
+++ b/src/legacy.c
@@ -473,8 +473,7 @@ static void legacyFireChange(struct raft_change *req)
     req->cb(req, req->status);
 }
 
-/* Fire the callbacks of all completed requests */
-static void legacyFireCompletedRequests(struct raft *r)
+void LegacyFireCompletedRequests(struct raft *r)
 {
     while (!QUEUE_IS_EMPTY(&r->legacy.requests)) {
         struct request *req;
@@ -531,7 +530,7 @@ int LegacyForwardToRaftIo(struct raft *r, struct raft_event *event)
             goto err;
         }
 
-        legacyFireCompletedRequests(r);
+        LegacyFireCompletedRequests(r);
 
         if (legacyShouldTakeSnapshot(r)) {
             legacyTakeSnapshot(r);

--- a/src/legacy.c
+++ b/src/legacy.c
@@ -4,7 +4,9 @@
 #include "err.h"
 #include "log.h"
 #include "membership.h"
+#include "queue.h"
 #include "replication.h"
+#include "request.h"
 #include "tracing.h"
 
 #define tracef(...) Tracef(r->tracer, __VA_ARGS__)
@@ -456,6 +458,44 @@ abort:
     return;
 }
 
+static void legacyFireApply(struct raft_apply *req)
+{
+    req->cb(req, req->status, req->result);
+}
+
+static void legacyFireBarrier(struct raft_barrier *req)
+{
+    req->cb(req, req->status);
+}
+
+static void legacyFireChange(struct raft_change *req)
+{
+    req->cb(req, req->status);
+}
+
+/* Fire the callbacks of all completed requests */
+static void legacyFireCompletedRequests(struct raft *r)
+{
+    while (!QUEUE_IS_EMPTY(&r->legacy.requests)) {
+        struct request *req;
+        queue *head;
+        head = QUEUE_HEAD(&r->legacy.requests);
+        QUEUE_REMOVE(head);
+        req = QUEUE_DATA(head, struct request, queue);
+        switch (req->type) {
+            case RAFT_COMMAND:
+                legacyFireApply((struct raft_apply *)req);
+                break;
+            case RAFT_BARRIER:
+                legacyFireBarrier((struct raft_barrier *)req);
+                break;
+            case RAFT_CHANGE:
+                legacyFireChange((struct raft_change *)req);
+                break;
+        };
+    }
+}
+
 int LegacyForwardToRaftIo(struct raft *r, struct raft_event *event)
 {
     struct raft_event *events;
@@ -490,6 +530,8 @@ int LegacyForwardToRaftIo(struct raft *r, struct raft_event *event)
         if (rv != 0) {
             goto err;
         }
+
+        legacyFireCompletedRequests(r);
 
         if (legacyShouldTakeSnapshot(r)) {
             legacyTakeSnapshot(r);

--- a/src/legacy.h
+++ b/src/legacy.h
@@ -9,4 +9,7 @@
  * legacy raft_io interface. */
 int LegacyForwardToRaftIo(struct raft *r, struct raft_event *event);
 
+/* Fire the callbacks of all completed client requests. */
+void LegacyFireCompletedRequests(struct raft *r);
+
 #endif /* RAFT_LEGACY_H_ */

--- a/src/membership.c
+++ b/src/membership.c
@@ -7,6 +7,7 @@
 #include "heap.h"
 #include "log.h"
 #include "progress.h"
+#include "queue.h"
 #include "task.h"
 #include "tracing.h"
 
@@ -249,6 +250,7 @@ void membershipLeadershipTransferClose(struct raft *r)
     raft_transfer_cb cb = req->cb;
     r->transfer = NULL;
     if (cb != NULL) {
-        cb(req);
+        req->type = RAFT_TRANSFER;
+        QUEUE_PUSH(&r->legacy.requests, &req->queue);
     }
 }

--- a/src/raft.c
+++ b/src/raft.c
@@ -11,6 +11,7 @@
 #include "err.h"
 #include "flags.h"
 #include "heap.h"
+#include "legacy.h"
 #include "log.h"
 #include "membership.h"
 #include "queue.h"
@@ -150,6 +151,9 @@ void raft_close(struct raft *r, void (*cb)(struct raft *r))
     assert(r->close_cb == NULL);
     if (r->state != RAFT_UNAVAILABLE) {
         convertToUnavailable(r);
+        if (r->io != NULL) {
+            LegacyFireCompletedRequests(r);
+        }
     }
     r->close_cb = cb;
     if (r->io != NULL) {

--- a/src/raft.c
+++ b/src/raft.c
@@ -109,6 +109,7 @@ int raft_init(struct raft *r,
         }
         r->now = r->io->time(r->io);
         raft_seed(r, (unsigned)r->io->random(r->io, 0, INT_MAX));
+        r->legacy.last_applied = 0;
     }
     r->tasks = NULL;
     r->n_tasks = 0;

--- a/src/raft.c
+++ b/src/raft.c
@@ -13,6 +13,7 @@
 #include "heap.h"
 #include "log.h"
 #include "membership.h"
+#include "queue.h"
 #include "recv.h"
 #include "replication.h"
 #include "tracing.h"
@@ -110,6 +111,7 @@ int raft_init(struct raft *r,
         r->now = r->io->time(r->io);
         raft_seed(r, (unsigned)r->io->random(r->io, 0, INT_MAX));
         r->legacy.last_applied = 0;
+        QUEUE_INIT(&r->legacy.requests);
     }
     r->tasks = NULL;
     r->n_tasks = 0;

--- a/src/replication.c
+++ b/src/replication.c
@@ -469,21 +469,25 @@ static int leaderPersistEntriesDone(struct raft *r,
                 case RAFT_COMMAND: {
                     struct raft_apply *apply = (struct raft_apply *)req;
                     if (apply->cb) {
-                        apply->cb(apply, status, NULL);
+                        apply->status = status;
+                        apply->result = NULL;
+                        QUEUE_PUSH(&r->legacy.requests, &apply->queue);
                     }
                     break;
                 }
                 case RAFT_BARRIER: {
                     struct raft_barrier *barrier = (struct raft_barrier *)req;
                     if (barrier->cb) {
-                        barrier->cb(barrier, status);
+                        barrier->status = status;
+                        QUEUE_PUSH(&r->legacy.requests, &barrier->queue);
                     }
                     break;
                 }
                 case RAFT_CHANGE: {
                     struct raft_change *change = (struct raft_change *)req;
                     if (change->cb) {
-                        change->cb(change, status);
+                        change->status = status;
+                        QUEUE_PUSH(&r->legacy.requests, &change->queue);
                     }
                     break;
                 }

--- a/src/restore.c
+++ b/src/restore.c
@@ -229,13 +229,6 @@ int raft_start(struct raft *r)
         snapshot_term = snapshot->term;
         raft_free(snapshot);
 
-        /* Use a dummy event to trigger handling of the RAFT_RESTORE_SNAPSHOT
-         * task.
-         *
-         * TODO: use the start event instead. */
-        event.type = 255;
-        event.time = r->now;
-        LegacyForwardToRaftIo(r, &event);
     } else if (n_entries > 0) {
         /* If we don't have a snapshot and the on-disk log is not empty, then
          * the first entry must be a configuration entry. */

--- a/src/tick.c
+++ b/src/tick.c
@@ -6,6 +6,7 @@
 #include "legacy.h"
 #include "membership.h"
 #include "progress.h"
+#include "queue.h"
 #include "replication.h"
 #include "tracing.h"
 
@@ -184,7 +185,10 @@ static int tickLeader(struct raft *r)
             change = r->leader_state.change;
             r->leader_state.change = NULL;
             if (change != NULL && change->cb != NULL) {
-                change->cb(change, RAFT_NOCONNECTION);
+                /* XXX: set the type here, since it's not done in client.c */
+                change->type = RAFT_CHANGE;
+                change->status = RAFT_NOCONNECTION;
+                QUEUE_PUSH(&r->legacy.requests, &change->queue);
             }
         }
     }


### PR DESCRIPTION
In v1 client requests will be managed by consumer code, so this PR moves to the legacy compatibility code all the logic for firing client requests.