### PR TITLE
replication: Revert eager commit index update

### DIFF
--- a/src/replication.c
+++ b/src/replication.c
@@ -1101,8 +1101,9 @@ int replicationAppend(struct raft *r,
      *   commitIndex, set commitIndex = min(leaderCommit, index of last new
      *   entry).
      */
-    if (args->leader_commit > r->commit_index) {
-        r->commit_index = min(args->leader_commit, logLastIndex(r->log));
+    if (args->leader_commit > r->commit_index &&
+        r->last_stored >= r->commit_index) {
+        r->commit_index = min(args->leader_commit, r->last_stored);
     }
 
     /* If this is an empty AppendEntries, there's nothing to write. However we

--- a/test/integration/test_snapshot.c
+++ b/test/integration/test_snapshot.c
@@ -551,13 +551,8 @@ TEST(snapshot, installSnapshotDuringEntriesWrite, setUp, tearDown, 0, NULL)
     /* Set a large disk latency on the follower, this will allow a
      * InstallSnapshot RPC to arrive while the entries are being persisted. */
     CLUSTER_SET_DISK_LATENCY(1, 2000);
-
-    /* Set a low snapshot threshold on the leader (only do that on the leader,
-     * and not on the follower, otherwise the follower would trigger a snapshot
-     * and then receive the InstallSnapshot message while the snapshot is in
-     * progress, and would reject it. */
-    raft_set_snapshot_threshold(CLUSTER_RAFT(0), 3);
-    raft_set_snapshot_trailing(CLUSTER_RAFT(0), 1);
+    SET_SNAPSHOT_THRESHOLD(3);
+    SET_SNAPSHOT_TRAILING(1);
 
     /* Replicate some entries, these will take a while to persist */
     CLUSTER_MAKE_PROGRESS;


### PR DESCRIPTION
Revert the change in #95 that does not wait for entries to be persisted before advancing the commit index, since cowsql and raft_io are not yet prepared to handle the resulting edge cases.