### PR TITLE
v1: Fire request callbacks after raft step() when leadership is lost

### DIFF
--- a/include/raft.h
+++ b/include/raft.h
@@ -1218,21 +1218,42 @@ RAFT_API raft_index raft_last_index(struct raft *r);
  */
 RAFT_API raft_index raft_last_applied(struct raft *r);
 
+/* Unused uint64_t slots that are reserved for v0.x extensions.*/
+#define RAFT__REQUEST_RESERVED \
+    struct                     \
+    {                          \
+        uint64_t reserved[4];  \
+    }
+
+/* Extended RAFT__REQUEST fields added after the v0.x ABI freeze. */
+#define RAFT__REQUEST_EXTENSIONS                                              \
+    struct                                                                    \
+    {                                                                         \
+        int status;   /* Store the request status code, for delayed firing */ \
+        void *result; /* For raft_apply, store the request result */          \
+    }
+
+RAFT__ASSERT_COMPATIBILITY(RAFT__REQUEST_RESERVED, RAFT__REQUEST_EXTENSIONS);
+
 /**
  * Common fields across client request types.
  * `req_id`, `client_id` and `unique_id` are currently unused.
  * `reserved` fields should be replaced by new members with the same size
  * and alignment requirements as `uint64_t`.
  */
-#define RAFT__REQUEST      \
-    void *data;            \
-    int type;              \
-    raft_index index;      \
-    void *queue[2];        \
-    uint8_t req_id[16];    \
-    uint8_t client_id[16]; \
-    uint8_t unique_id[16]; \
-    uint64_t reserved[4]
+#define RAFT__REQUEST                                                         \
+    void *data;                                                               \
+    int type;                                                                 \
+    raft_index index;                                                         \
+    void *queue[2];                                                           \
+    uint8_t req_id[16];                                                       \
+    uint8_t client_id[16];                                                    \
+    uint8_t unique_id[16];                                                    \
+    /* Fields added after the v0.x ABI freeze, packed in the unused space. */ \
+    union {                                                                   \
+        RAFT__REQUEST_RESERVED;                                               \
+        RAFT__REQUEST_EXTENSIONS;                                             \
+    }
 
 /**
  * Asynchronous request to append a new command entry to the log and apply it to

--- a/include/raft.h
+++ b/include/raft.h
@@ -806,6 +806,11 @@ struct raft_log;
         unsigned n_tasks_cap;    /* Capacity of the task queue */            \
         /* Index of the last snapshot that was taken */                      \
         raft_index configuration_last_snapshot_index;                        \
+        /* Fields used by the v0 compatibility code */                       \
+        struct                                                               \
+        {                                                                    \
+            void *requests[2]; /* Completed client requests */               \
+        } legacy;                                                            \
     }
 
 RAFT__ASSERT_COMPATIBILITY(RAFT__RESERVED, RAFT__EXTENSIONS);

--- a/src/legacy.h
+++ b/src/legacy.h
@@ -9,4 +9,7 @@
  * legacy raft_io interface. */
 int LegacyForwardToRaftIo(struct raft *r, struct raft_event *event);
 
+/* Fire the callbacks of all completed client requests. */
+void LegacyFireCompletedRequests(struct raft *r);
+
 #endif /* RAFT_LEGACY_H_ */

--- a/src/raft.c
+++ b/src/raft.c
@@ -13,6 +13,7 @@
 #include "heap.h"
 #include "log.h"
 #include "membership.h"
+#include "queue.h"
 #include "recv.h"
 #include "replication.h"
 #include "tracing.h"
@@ -109,6 +110,7 @@ int raft_init(struct raft *r,
         }
         r->now = r->io->time(r->io);
         raft_seed(r, (unsigned)r->io->random(r->io, 0, INT_MAX));
+        QUEUE_INIT(&r->legacy.requests);
     }
     r->tasks = NULL;
     r->n_tasks = 0;

--- a/src/raft.c
+++ b/src/raft.c
@@ -11,6 +11,7 @@
 #include "err.h"
 #include "flags.h"
 #include "heap.h"
+#include "legacy.h"
 #include "log.h"
 #include "membership.h"
 #include "queue.h"
@@ -149,6 +150,9 @@ void raft_close(struct raft *r, void (*cb)(struct raft *r))
     assert(r->close_cb == NULL);
     if (r->state != RAFT_UNAVAILABLE) {
         convertToUnavailable(r);
+        if (r->io != NULL) {
+            LegacyFireCompletedRequests(r);
+        }
     }
     r->close_cb = cb;
     if (r->io != NULL) {

--- a/src/restore.c
+++ b/src/restore.c
@@ -229,13 +229,6 @@ int raft_start(struct raft *r)
         snapshot_term = snapshot->term;
         raft_free(snapshot);
 
-        /* Use a dummy event to trigger handling of the RAFT_RESTORE_SNAPSHOT
-         * task.
-         *
-         * TODO: use the start event instead. */
-        event.type = 255;
-        event.time = r->now;
-        LegacyForwardToRaftIo(r, &event);
     } else if (n_entries > 0) {
         /* If we don't have a snapshot and the on-disk log is not empty, then
          * the first entry must be a configuration entry. */


### PR DESCRIPTION
Instead of firing request callbacks synchronously when stepping down from leader, enqueue them in a new `legacy.requests` queue and fire them all after the running `raft_step()` call has returned.

This is a step towards decoupling `raft_step()` from `raft_fsm`/`raft_io` code.