### PR TITLE
legacy: Add a `step_cb()` callback which filres after each `raft_step()` call

### DIFF
--- a/include/raft.h
+++ b/include/raft.h
@@ -809,7 +809,8 @@ struct raft_log;
         /* Fields used by the v0 compatibility code */                       \
         struct                                                               \
         {                                                                    \
-            void *requests[2]; /* Completed client requests */               \
+            void *requests[2];              /* Completed client requests */  \
+            void (*step_cb)(struct raft *); /* Invoked after raft_step() */  \
         } legacy;                                                            \
     }
 

--- a/src/legacy.c
+++ b/src/legacy.c
@@ -330,6 +330,11 @@ static void takeSnapshotCb(struct raft_io_snapshot_put *put, int status)
     takeSnapshotClose(r, snapshot);
     raft_free(req);
 
+    if (r->state == RAFT_UNAVAILABLE) {
+        tracef("cancelling snapshot");
+        status = RAFT_CANCELED;
+    }
+
     if (status != 0) {
         tracef("snapshot %lld at term %lld: %s", snapshot->index,
                snapshot->term, raft_strerror(status));

--- a/src/legacy.c
+++ b/src/legacy.c
@@ -537,6 +537,10 @@ int LegacyForwardToRaftIo(struct raft *r, struct raft_event *event)
 
         LegacyFireCompletedRequests(r);
 
+        if (r->legacy.step_cb != NULL) {
+            r->legacy.step_cb(r);
+        }
+
         if (legacyShouldTakeSnapshot(r)) {
             legacyTakeSnapshot(r);
         }

--- a/src/raft.c
+++ b/src/raft.c
@@ -112,6 +112,7 @@ int raft_init(struct raft *r,
         r->now = r->io->time(r->io);
         raft_seed(r, (unsigned)r->io->random(r->io, 0, INT_MAX));
         QUEUE_INIT(&r->legacy.requests);
+        r->legacy.step_cb = NULL;
     }
     r->tasks = NULL;
     r->n_tasks = 0;

--- a/src/raft.c
+++ b/src/raft.c
@@ -149,6 +149,7 @@ static void ioCloseCb(struct raft_io *io)
 void raft_close(struct raft *r, void (*cb)(struct raft *r))
 {
     assert(r->close_cb == NULL);
+    assert(r->n_tasks == 0);
     if (r->state != RAFT_UNAVAILABLE) {
         convertToUnavailable(r);
         if (r->io != NULL) {


### PR DESCRIPTION
The cowsql code needs to immediately detect when leadership lost after a `raft_step()` call, in order to close all client connections. So far, this has been done using a `uv_prepare` handle, but that is unreliable, since a lot of data might accumulate in the kernel TCP buffers when for example the process is paused (e.g. by the Jepsen nemesis), and the prepare handle does not have a chance to run.

This branch also fixes a few other bugs that were surfaced by Jepsen tests.