### PR TITLE
legacy: Don't take a snapshot if InstallSnapshot just failed

### DIFF
--- a/src/legacy.c
+++ b/src/legacy.c
@@ -398,6 +398,13 @@ static bool legacyShouldTakeSnapshot(struct raft *r)
         return false;
     }
 
+    /* If the last committed index is not anymore in our log, it means that the
+     * log got truncated because we have received an InstallSnapshot
+     * message. Don't take a snapshot now.*/
+    if (logTermOf(r->log, r->commit_index) == 0) {
+        return false;
+    }
+
     return true;
 }
 


### PR DESCRIPTION
This is a corner case surfaced by jepsen tests. There should be a better solution, but this should fix the issue for now.