### PR TITLE
log: Don't append duplicate entries that are still referenced

### DIFF
--- a/src/recv_append_entries.c
+++ b/src/recv_append_entries.c
@@ -116,7 +116,7 @@ int recvAppendEntries(struct raft *r,
     }
 
     rv = replicationAppend(r, args, &result->rejected, &async);
-    if (rv != 0) {
+    if (rv != 0 && rv != RAFT_BUSY) {
         return rv;
     }
 

--- a/src/replication.c
+++ b/src/replication.c
@@ -1069,8 +1069,6 @@ int replicationAppend(struct raft *r,
         return rv;
     }
 
-    *rejected = 0;
-
     n = args->n_entries - i; /* Number of new entries */
 
     /* Update our in-memory log to reflect that we received these entries. We'll
@@ -1091,9 +1089,12 @@ int replicationAppend(struct raft *r,
 
         rv = logAppend(r->log, copy.term, copy.type, &copy.buf, NULL);
         if (rv != 0) {
+            raft_free(copy.buf.base);
             goto err;
         }
     }
+
+    *rejected = 0;
 
     /* From Figure 3.1:
      *

--- a/test/unit/test_log.c
+++ b/test/unit/test_log.c
@@ -625,6 +625,29 @@ TEST(logAppend, oomRefs, setUp, tearDown, 0, NULL)
     return MUNIT_OK;
 }
 
+/* Return an error when trying to append an entry with the same index and term
+ * of an older entry that got trucated but its still referenced. */
+TEST(logAppend, busy, setUp, tearDown, 0, NULL)
+{
+    struct fixture *f = data;
+    struct raft_entry *entries1;
+    struct raft_entry *entries2;
+    struct raft_entry *entries;
+    unsigned n;
+    APPEND(1 /* term */);
+    ACQUIRE(1);
+    entries1 = entries;
+    ACQUIRE(1);
+    entries2 = entries;
+    TRUNCATE(1);
+    entries = entries1;
+    RELEASE(1);
+    APPEND_ERROR(1 /* term */, RAFT_BUSY);
+    entries = entries2;
+    RELEASE(1);
+    return MUNIT_OK;
+}
+
 /******************************************************************************
  *
  * logAppendConfiguration


### PR DESCRIPTION
This fixes the following scenario, surfaced by Jepsen tests:

- a leader appends a new entry E to its log
- it also sends E to followers
- the disk write for E fails, while E is still being sent
- the leader steps down
- the ex-leader receives E from a follower, while it is still waiting for the original send operation of E to complete on all followers

In that case, E is still referenced by the local log when it gets received, which leads to an assertion failure.