### PR TITLE
v1: Trigger client callbacks after `raft_step()`

### DIFF
--- a/src/fixture.c
+++ b/src/fixture.c
@@ -9,6 +9,7 @@
 #include "configuration.h"
 #include "convert.h"
 #include "entry.h"
+#include "legacy.h"
 #include "log.h"
 #include "queue.h"
 #include "random.h"
@@ -1504,6 +1505,11 @@ struct raft_fixture_event *raft_fixture_step(struct raft_fixture *f)
         fireTick(f, i);
     } else {
         completeRequest(f, j, completion_time);
+    }
+
+    for (j = 0; j < f->n; j++) {
+        struct raft *r = &f->servers[j]->raft;
+        LegacyFireCompletedRequests(r);
     }
 
     /* If the leader has not changed check the Leader Append-Only

--- a/src/legacy.c
+++ b/src/legacy.c
@@ -551,8 +551,6 @@ int LegacyForwardToRaftIo(struct raft *r, struct raft_event *event)
             goto err;
         }
 
-        LegacyFireCompletedRequests(r);
-
         if (r->legacy.step_cb != NULL) {
             r->legacy.step_cb(r);
         }

--- a/src/legacy.c
+++ b/src/legacy.c
@@ -494,6 +494,11 @@ static void legacyFireChange(struct raft_change *req)
     req->cb(req, req->status);
 }
 
+static void legacyFireTransfer(struct raft_transfer *req)
+{
+    req->cb(req);
+}
+
 void LegacyFireCompletedRequests(struct raft *r)
 {
     while (!QUEUE_IS_EMPTY(&r->legacy.requests)) {
@@ -511,6 +516,13 @@ void LegacyFireCompletedRequests(struct raft *r)
                 break;
             case RAFT_CHANGE:
                 legacyFireChange((struct raft_change *)req);
+                break;
+            case RAFT_TRANSFER:
+                legacyFireTransfer((struct raft_transfer *)req);
+                break;
+            default:
+                tracef("unknown request type, shutdown.");
+                assert(false);
                 break;
         };
     }

--- a/src/legacy.c
+++ b/src/legacy.c
@@ -57,9 +57,9 @@ static void ioSendMessageCb(struct raft_io_send *send, int status)
 
 static int ioSendMessage(struct raft *r, struct raft_task *task)
 {
-    struct raft_send_message *params = &task->send_message;
+    struct raft_send_message *params;
     struct ioForwardSendMessage *req;
-    struct raft_message message;
+    struct raft_message *message;
     int rv;
 
     req = raft_malloc(sizeof *req);
@@ -70,11 +70,13 @@ static int ioSendMessage(struct raft *r, struct raft_task *task)
     req->task = *task;
     req->send.data = req;
 
-    message = params->message;
-    message.server_id = params->id;
-    message.server_address = params->address;
+    params = &req->task.send_message;
 
-    rv = r->io->send(r->io, &req->send, &message, ioSendMessageCb);
+    message = &params->message;
+    message->server_id = params->id;
+    message->server_address = params->address;
+
+    rv = r->io->send(r->io, &req->send, message, ioSendMessageCb);
     if (rv != 0) {
         raft_free(req);
         ErrMsgTransferf(r->io->errmsg, r->errmsg,

--- a/src/legacy.c
+++ b/src/legacy.c
@@ -345,8 +345,8 @@ static void takeSnapshotCb(struct raft_io_snapshot_put *put, int status)
     }
 
     if (status != 0) {
-        tracef("snapshot %lld at term %lld: %s", snapshot->index,
-               snapshot->term, raft_strerror(status));
+        tracef("snapshot %lld at term %lld: %s", metadata.index, metadata.term,
+               raft_strerror(status));
         configurationClose(&metadata.configuration);
         return;
     }

--- a/src/membership.c
+++ b/src/membership.c
@@ -7,6 +7,7 @@
 #include "heap.h"
 #include "log.h"
 #include "progress.h"
+#include "queue.h"
 #include "task.h"
 #include "tracing.h"
 
@@ -246,9 +247,9 @@ int membershipLeadershipTransferStart(struct raft *r)
 void membershipLeadershipTransferClose(struct raft *r)
 {
     struct raft_transfer *req = r->transfer;
-    raft_transfer_cb cb = req->cb;
     r->transfer = NULL;
-    if (cb != NULL) {
-        cb(req);
+    if (req->cb != NULL) {
+        req->type = RAFT_TRANSFER;
+        QUEUE_PUSH(&r->legacy.requests, &req->queue);
     }
 }

--- a/src/membership.h
+++ b/src/membership.h
@@ -5,6 +5,10 @@
 
 #include "../include/raft.h"
 
+/* XXX Internal code for transfer request objects. Used by the legacy layer to
+ * differentiate between items in the legacy.requests queue. */
+#define RAFT_TRANSFER (RAFT_CHANGE + 1)
+
 /* Helper returning an error if the configuration can't be changed, either
  * because this node is not the leader or because a configuration change is
  * already in progress. */

--- a/src/replication.c
+++ b/src/replication.c
@@ -1330,7 +1330,9 @@ static int applyCommand(struct raft *r,
 
     req = (struct raft_apply *)getRequest(r, index, RAFT_COMMAND);
     if (req != NULL && req->cb != NULL) {
-        req->cb(req, 0, result);
+        req->status = 0;
+        req->result = result;
+        QUEUE_PUSH(&r->legacy.requests, &req->queue);
     }
     return 0;
 }
@@ -1343,7 +1345,8 @@ static void applyBarrier(struct raft *r, const raft_index index)
     struct raft_barrier *req;
     req = (struct raft_barrier *)getRequest(r, index, RAFT_BARRIER);
     if (req != NULL && req->cb != NULL) {
-        req->cb(req, 0);
+        req->status = 0;
+        QUEUE_PUSH(&r->legacy.requests, &req->queue);
     }
 }
 
@@ -1387,7 +1390,10 @@ static void applyChange(struct raft *r, const raft_index index)
         }
 
         if (req != NULL && req->cb != NULL) {
-            req->cb(req, 0);
+            /* XXX: set the type here, since it's not done in client.c */
+            req->type = RAFT_CHANGE;
+            req->status = 0;
+            QUEUE_PUSH(&r->legacy.requests, &req->queue);
         }
     }
 }

--- a/src/replication.c
+++ b/src/replication.c
@@ -460,7 +460,7 @@ static int leaderPersistEntriesDone(struct raft *r,
         ErrMsgTransfer(r->io->errmsg, r->errmsg, "io");
 
         for (unsigned i = 0; i < params->n; i++) {
-            const struct request *req = getRequest(r, params->index + i, -1);
+            struct request *req = getRequest(r, params->index + i, -1);
             if (!req) {
                 tracef("no request found at index %llu", params->index + i);
                 continue;
@@ -469,21 +469,25 @@ static int leaderPersistEntriesDone(struct raft *r,
                 case RAFT_COMMAND: {
                     struct raft_apply *apply = (struct raft_apply *)req;
                     if (apply->cb) {
-                        apply->cb(apply, status, NULL);
+                        apply->status = status;
+                        apply->result = NULL;
+                        QUEUE_PUSH(&r->legacy.requests, &apply->queue);
                     }
                     break;
                 }
                 case RAFT_BARRIER: {
                     struct raft_barrier *barrier = (struct raft_barrier *)req;
                     if (barrier->cb) {
-                        barrier->cb(barrier, status);
+                        barrier->status = status;
+                        QUEUE_PUSH(&r->legacy.requests, &barrier->queue);
                     }
                     break;
                 }
                 case RAFT_CHANGE: {
                     struct raft_change *change = (struct raft_change *)req;
                     if (change->cb) {
-                        change->cb(change, status);
+                        change->status = status;
+                        QUEUE_PUSH(&r->legacy.requests, &change->queue);
                     }
                     break;
                 }

--- a/src/tick.c
+++ b/src/tick.c
@@ -6,6 +6,7 @@
 #include "legacy.h"
 #include "membership.h"
 #include "progress.h"
+#include "queue.h"
 #include "replication.h"
 #include "tracing.h"
 
@@ -184,7 +185,9 @@ static int tickLeader(struct raft *r)
             change = r->leader_state.change;
             r->leader_state.change = NULL;
             if (change != NULL && change->cb != NULL) {
-                change->cb(change, RAFT_NOCONNECTION);
+                change->type = RAFT_CHANGE;
+                change->status = RAFT_NOCONNECTION;
+                QUEUE_PUSH(&r->legacy.requests, &change->queue);
             }
         }
     }

--- a/src/uv.h
+++ b/src/uv.h
@@ -93,6 +93,8 @@ struct uv
     bool closing;                        /* True if we are closing */
     raft_io_close_cb close_cb;           /* Invoked when finishing closing */
     bool auto_recovery; /* Try to recover from corrupt segments */
+    struct uv_prepare_s prepare;
+    struct uv_check_s check;
 };
 
 /* Implementation of raft_io->truncate. */

--- a/src/uv_truncate.c
+++ b/src/uv_truncate.c
@@ -160,7 +160,6 @@ int UvTruncate(struct raft_io *io, raft_index index)
     int rv;
 
     uv = io->impl;
-    tracef("uv truncate %llu", index);
     assert(!uv->closing);
 
     /* We should truncate only entries that we were requested to append in the
@@ -170,6 +169,8 @@ int UvTruncate(struct raft_io *io, raft_index index)
     if (index >= uv->append_next_index) {
         return 0;
     }
+
+    tracef("uv truncate %llu", index);
 
     truncate = RaftHeapMalloc(sizeof *truncate);
     if (truncate == NULL) {

--- a/test/integration/test_uv_recv.c
+++ b/test/integration/test_uv_recv.c
@@ -232,6 +232,7 @@ static void *setUpDeps(const MunitParameter params[], void *user_data)
     SETUP_UV_DEPS;
     SETUP_TCP;
     PEER_SETUP;
+    f->io.version = 0; /* Magic value to avoid assuming that io.data is raft */
     f->io.data = f;
     f->closed = false;
     return f;
@@ -251,6 +252,7 @@ static void *setUp(const MunitParameter params[], void *user_data)
     struct fixture *f = setUpDeps(params, user_data);
     int rv;
     SETUP_UV;
+    f->io.version = 0; /* Magic value to avoid assuming that io.data is raft */
     f->io.data = f;
     rv = f->io.start(&f->io, 10000, NULL, recvCb);
     munit_assert_int(rv, ==, 0);

--- a/test/integration/test_uv_send.c
+++ b/test/integration/test_uv_send.c
@@ -91,6 +91,7 @@ static void *setUpDeps(const MunitParameter params[], void *user_data)
     struct fixture *f = munit_malloc(sizeof *f);
     SETUP_UV_DEPS;
     SETUP_TCP_SERVER;
+    f->io.version = 0; /* Magic value to avoid assuming that io.data is raft */
     f->io.data = f;
     return f;
 }


### PR DESCRIPTION
Move the code that triggers client callbacks out of `raft_step()` into the legacy compatibility layer. In v1, managing this kind of logic will be responsibility of user code.