### PR TITLE
v1: Move pending client requests queue to the legacy compat code

### DIFF
--- a/include/raft.h
+++ b/include/raft.h
@@ -561,6 +561,7 @@ typedef void (*raft_io_close_cb)(struct raft_io *io);
  */
 enum {
     RAFT_START = 1, /* Initial event starting the engine with persisted data. */
+    RAFT_STOP,
     RAFT_PERSISTED_ENTRIES,  /* A batch of entries have been persisted. */
     RAFT_PERSISTED_SNAPSHOT, /* A snapshot has been persisted. */
     RAFT_SENT,     /* A message has been sent (either successfully or not). */

--- a/include/raft.h
+++ b/include/raft.h
@@ -803,7 +803,8 @@ struct raft_log;
         /* Fields used by the v0 compatibility code */                      \
         struct                                                              \
         {                                                                   \
-            void *requests[2];              /* Completed client requests */ \
+            unsigned short prev_state; /* Used to detect lost leadership */ \
+            void *requests[2];         /* Completed client requests */      \
             void (*step_cb)(struct raft *); /* Invoked after raft_step() */ \
         } legacy;                                                           \
     }

--- a/include/raft.h
+++ b/include/raft.h
@@ -1103,6 +1103,11 @@ RAFT_API raft_term raft_current_term(struct raft *r);
 RAFT_API raft_id raft_voted_for(struct raft *r);
 
 /**
+ * Return the commit index of this server.
+ */
+RAFT_API raft_index raft_commit_index(struct raft *r);
+
+/**
  * Return information about the progress of a server that is catching up with
  * logs after a #RAFT_CATCH_UP event was fired.
  */

--- a/include/raft.h
+++ b/include/raft.h
@@ -804,6 +804,7 @@ struct raft_log;
         struct                                                              \
         {                                                                   \
             unsigned short prev_state; /* Used to detect lost leadership */ \
+            void *pending[2];          /* Pending client requests */        \
             void *requests[2];         /* Completed client requests */      \
             void (*step_cb)(struct raft *); /* Invoked after raft_step() */ \
         } legacy;                                                           \
@@ -987,7 +988,6 @@ struct raft
             unsigned short round_number;    /* Current sync round. */
             raft_index round_index;         /* Target of the current round. */
             raft_time round_start;          /* Start of current round. */
-            void *requests[2];              /* Outstanding client requests. */
             uint64_t reserved[8];           /* Future use */
         } leader_state;
     };

--- a/include/raft.h
+++ b/include/raft.h
@@ -1103,8 +1103,21 @@ RAFT_API raft_term raft_current_term(struct raft *r);
 RAFT_API raft_id raft_voted_for(struct raft *r);
 
 /**
- * Bootstrap this raft instance using the given configuration. The instance must
- * not have been started yet and must be completely pristine, otherwise
+ * Return information about the progress of a server that is catching up with
+ * logs after a #RAFT_CATCH_UP event was fired.
+ */
+enum {
+    RAFT_CATCH_UP_NONE,
+    RAFT_CATCH_UP_RUNNING,
+    RAFT_CATCH_UP_ABORTED,
+    RAFT_CATCH_UP_FINISHED
+};
+
+RAFT_API int raft_catch_up(struct raft *r, raft_id id, int *status);
+
+/**
+ * Bootstrap this raft instance using the given configuration. The instance
+ * must not have been started yet and must be completely pristine, otherwise
  * #RAFT_CANTBOOTSTRAP will be returned.
  */
 RAFT_API int raft_bootstrap(struct raft *r,

--- a/include/raft.h
+++ b/include/raft.h
@@ -671,6 +671,7 @@ struct raft_update
 #define RAFT_UPDATE_ENTRIES 1 << 2
 #define RAFT_UPDATE_SNAPSHOT 1 << 3
 #define RAFT_UPDATE_MESSAGES 1 << 4
+#define RAFT_UPDATE_STATE 1 << 5
 
 /**
  * version field MUST be filled out by user.

--- a/include/raft.h
+++ b/include/raft.h
@@ -808,6 +808,7 @@ struct raft_log;
             void *pending[2];          /* Pending client requests */        \
             void *requests[2];         /* Completed client requests */      \
             void (*step_cb)(struct raft *); /* Invoked after raft_step() */ \
+            struct raft_change *change;     /* Pending membership change */ \
         } legacy;                                                           \
     }
 
@@ -984,7 +985,6 @@ struct raft
         struct
         {
             struct raft_progress *progress; /* Per-server replication state. */
-            struct raft_change *change;     /* Pending membership change. */
             raft_id promotee_id;            /* ID of server being promoted. */
             unsigned short round_number;    /* Current sync round. */
             raft_index round_index;         /* Target of the current round. */
@@ -1252,8 +1252,11 @@ RAFT_API raft_index raft_last_applied(struct raft *r);
 #define RAFT__REQUEST_EXTENSIONS                                              \
     struct                                                                    \
     {                                                                         \
-        int status;   /* Store the request status code, for delayed firing */ \
-        void *result; /* For raft_apply, store the request result */          \
+        int status; /* Store the request status code, for delayed firing */   \
+        union {                                                               \
+            void *result;      /* For raft_apply, store the request result */ \
+            raft_id server_id; /* For raft_change, store the server ID */     \
+        };                                                                    \
     }
 
 RAFT__ASSERT_COMPATIBILITY(RAFT__REQUEST_RESERVED, RAFT__REQUEST_EXTENSIONS);

--- a/include/raft.h
+++ b/include/raft.h
@@ -1249,14 +1249,14 @@ RAFT_API raft_index raft_last_applied(struct raft *r);
     }
 
 /* Extended RAFT__REQUEST fields added after the v0.x ABI freeze. */
-#define RAFT__REQUEST_EXTENSIONS                                              \
-    struct                                                                    \
-    {                                                                         \
-        int status; /* Store the request status code, for delayed firing */   \
-        union {                                                               \
-            void *result;      /* For raft_apply, store the request result */ \
-            raft_id server_id; /* For raft_change, store the server ID */     \
-        };                                                                    \
+#define RAFT__REQUEST_EXTENSIONS                                               \
+    struct                                                                     \
+    {                                                                          \
+        int status; /* Store the request status code, for delayed firing */    \
+        union {                                                                \
+            void *result; /* For raft_apply, store the request result */       \
+            raft_id catch_up_id; /* For raft_change, the catching up server */ \
+        };                                                                     \
     }
 
 RAFT__ASSERT_COMPATIBILITY(RAFT__REQUEST_RESERVED, RAFT__REQUEST_EXTENSIONS);

--- a/include/raft.h
+++ b/include/raft.h
@@ -673,6 +673,7 @@ struct raft_update
 #define RAFT_UPDATE_SNAPSHOT 1 << 3
 #define RAFT_UPDATE_MESSAGES 1 << 4
 #define RAFT_UPDATE_STATE 1 << 5
+#define RAFT_UPDATE_COMMIT_INDEX 1 << 6
 
 /**
  * version field MUST be filled out by user.
@@ -791,25 +792,27 @@ struct raft_log;
     }
 
 /* Extended struct raft fields added after the v0.x ABI freeze. */
-#define RAFT__EXTENSIONS                                                    \
-    struct                                                                  \
-    {                                                                       \
-        raft_time now;   /* Current time, updated via raft_step() */        \
-        unsigned random; /* Pseudo-random number generator state */         \
-        struct raft_update *update;    /* Pointer passed to raft_step() */  \
-        struct raft_message *messages; /* Pre-allocated message queue */    \
-        unsigned n_messages_cap;       /* Capacity of the message queue */  \
-        /* Index of the last snapshot that was taken */                     \
-        raft_index configuration_last_snapshot_index;                       \
-        /* Fields used by the v0 compatibility code */                      \
-        struct                                                              \
-        {                                                                   \
-            unsigned short prev_state; /* Used to detect lost leadership */ \
-            void *pending[2];          /* Pending client requests */        \
-            void *requests[2];         /* Completed client requests */      \
-            void (*step_cb)(struct raft *); /* Invoked after raft_step() */ \
-            struct raft_change *change;     /* Pending membership change */ \
-        } legacy;                                                           \
+#define RAFT__EXTENSIONS                                                       \
+    struct                                                                     \
+    {                                                                          \
+        raft_time now;   /* Current time, updated via raft_step() */           \
+        unsigned random; /* Pseudo-random number generator state */            \
+        struct raft_update *update;    /* Pointer passed to raft_step() */     \
+        struct raft_message *messages; /* Pre-allocated message queue */       \
+        unsigned n_messages_cap;       /* Capacity of the message queue */     \
+        /* Index of the last snapshot that was taken */                        \
+        raft_index configuration_last_snapshot_index;                          \
+        /* Fields used by the v0 compatibility code */                         \
+        struct                                                                 \
+        {                                                                      \
+            unsigned short prev_state; /* Used to detect lost leadership */    \
+            void *pending[2];          /* Pending client requests */           \
+            void *requests[2];         /* Completed client requests */         \
+            void (*step_cb)(struct raft *);    /* Invoked after raft_step() */ \
+            struct raft_change *change;        /* Pending membership change */ \
+            raft_index snapshot_index;         /* Last persisted snapshot */   \
+            struct raft_buffer snapshot_chunk; /* Cache of snapshot data */    \
+        } legacy;                                                              \
     }
 
 RAFT__ASSERT_COMPATIBILITY(RAFT__RESERVED, RAFT__EXTENSIONS);

--- a/include/raft.h
+++ b/include/raft.h
@@ -564,13 +564,14 @@ enum {
     RAFT_STOP,
     RAFT_PERSISTED_ENTRIES,  /* A batch of entries have been persisted. */
     RAFT_PERSISTED_SNAPSHOT, /* A snapshot has been persisted. */
-    RAFT_SENT,     /* A message has been sent (either successfully or not). */
-    RAFT_RECEIVE,  /* A message has been received. */
-    RAFT_SNAPSHOT, /* A snapshot has been taken. */
-    RAFT_TIMEOUT,  /* The timeout has expired. */
-    RAFT_SUBMIT,   /* New entries have been submitted. */
-    RAFT_CATCH_UP, /* Start catching-up a server. */
-    RAFT_TRANSFER  /* Submission of leadership trasfer request */
+    RAFT_SENT,    /* A message has been sent (either successfully or not). */
+    RAFT_RECEIVE, /* A message has been received. */
+    RAFT_CONFIGURATION, /* A new committed configuration must be applied. */
+    RAFT_SNAPSHOT,      /* A snapshot has been taken. */
+    RAFT_TIMEOUT,       /* The timeout has expired. */
+    RAFT_SUBMIT,        /* New entries have been submitted. */
+    RAFT_CATCH_UP,      /* Start catching-up a server. */
+    RAFT_TRANSFER       /* Submission of leadership trasfer request */
 };
 
 /**
@@ -618,6 +619,10 @@ struct raft_event
             const char *address;
             struct raft_message *message;
         } receive;
+        struct
+        {
+            raft_index index;
+        } configuration;
         struct
         {
             struct raft_snapshot_metadata metadata; /* Snapshot metadata */

--- a/src/client.c
+++ b/src/client.c
@@ -303,6 +303,8 @@ void ClientCatchUp(struct raft *r, raft_id server_id)
     r->leader_state.round_index = last_index;
     r->leader_state.round_start = r->now;
 
+    progressCatchUpStart(r, server_index);
+
     /* Immediately initiate an AppendEntries request. */
     rv = replicationProgress(r, server_index);
     if (rv != 0 && rv != RAFT_NOCONNECTION) {

--- a/src/client.c
+++ b/src/client.c
@@ -140,7 +140,7 @@ int raft_apply(struct raft *r,
         return rv;
     }
 
-    QUEUE_PUSH(&r->leader_state.requests, &req->queue);
+    QUEUE_PUSH(&r->legacy.pending, &req->queue);
 
     return 0;
 }
@@ -178,7 +178,7 @@ int raft_barrier(struct raft *r, struct raft_barrier *req, raft_barrier_cb cb)
         goto err_after_buf_alloc;
     }
 
-    QUEUE_PUSH(&r->leader_state.requests, &req->queue);
+    QUEUE_PUSH(&r->legacy.pending, &req->queue);
 
     return 0;
 

--- a/src/client.c
+++ b/src/client.c
@@ -262,7 +262,7 @@ int raft_add(struct raft *r,
     }
 
     req->cb = cb;
-    req->server_id = id;
+    req->catch_up_id = 0;
 
     rv = clientChangeConfiguration(r, req, &configuration);
     if (rv != 0) {
@@ -377,7 +377,7 @@ int raft_assign(struct raft *r,
     last_index = logLastIndex(r->log);
 
     req->cb = cb;
-    req->server_id = id;
+    req->catch_up_id = 0;
 
     assert(r->legacy.change == NULL);
     r->legacy.change = req;
@@ -408,6 +408,8 @@ int raft_assign(struct raft *r,
     if (rv != 0) {
         return rv;
     }
+
+    req->catch_up_id = server->id;
 
     return 0;
 
@@ -451,7 +453,7 @@ int raft_remove(struct raft *r,
     }
 
     req->cb = cb;
-    req->server_id = id;
+    req->catch_up_id = 0;
 
     rv = clientChangeConfiguration(r, req, &configuration);
     if (rv != 0) {

--- a/src/client.h
+++ b/src/client.h
@@ -12,4 +12,8 @@ void ClientCatchUp(struct raft *r, raft_id server_id);
 /* Start transferring leadership to the given server. */
 int ClientTransfer(struct raft *r, raft_id server_id);
 
+/* Submit a new RAFT_CHANGE entry with the given new configuration. */
+int ClientChangeConfiguration(struct raft *r,
+                              const struct raft_configuration *configuration);
+
 #endif /* CLIENT_H_ */

--- a/src/convert.c
+++ b/src/convert.c
@@ -22,6 +22,7 @@ static void convertSetState(struct raft *r, unsigned short new_state)
      * respect to the paper we have an additional "unavailable" state, which is
      * the initial or final state. */
     tracef("old_state:%u new_state:%u", r->state, new_state);
+    assert(r->state != new_state);
     assert((r->state == RAFT_UNAVAILABLE && new_state == RAFT_FOLLOWER) ||
            (r->state == RAFT_FOLLOWER && new_state == RAFT_CANDIDATE) ||
            (r->state == RAFT_CANDIDATE && new_state == RAFT_FOLLOWER) ||
@@ -31,6 +32,7 @@ static void convertSetState(struct raft *r, unsigned short new_state)
            (r->state == RAFT_CANDIDATE && new_state == RAFT_UNAVAILABLE) ||
            (r->state == RAFT_LEADER && new_state == RAFT_UNAVAILABLE));
     r->state = new_state;
+    r->update->flags |= RAFT_UPDATE_STATE;
 }
 
 /* Clear follower state. */

--- a/src/convert.c
+++ b/src/convert.c
@@ -162,6 +162,7 @@ int convertToLeader(struct raft *r)
         tracef("apply log entries after self election %llu %llu",
                r->last_stored, r->commit_index);
         r->commit_index = r->last_stored;
+        r->update->flags |= RAFT_UPDATE_COMMIT_INDEX;
         rv = replicationApply(r);
     } else if (n_voters > 1) {
         /* Raft Dissertation, paragraph 6.4:

--- a/src/convert.c
+++ b/src/convert.c
@@ -163,7 +163,6 @@ int convertToLeader(struct raft *r)
                r->last_stored, r->commit_index);
         r->commit_index = r->last_stored;
         r->update->flags |= RAFT_UPDATE_COMMIT_INDEX;
-        rv = replicationApply(r);
     } else if (n_voters > 1) {
         /* Raft Dissertation, paragraph 6.4:
          * The Leader Completeness Property guarantees that a leader has all
@@ -189,12 +188,11 @@ int convertToLeader(struct raft *r)
                 "%d",
                 rv);
             raft_free(entry.buf.base);
-            goto out;
+            return rv;
         }
     }
 
-out:
-    return rv;
+    return 0;
 }
 
 void convertToUnavailable(struct raft *r)

--- a/src/fixture.c
+++ b/src/fixture.c
@@ -1729,6 +1729,7 @@ static bool hasAppliedIndex(struct raft_fixture *f, void *arg)
             n++;
         }
     }
+
     return n == f->n;
 }
 

--- a/src/legacy.c
+++ b/src/legacy.c
@@ -537,6 +537,10 @@ int LegacyForwardToRaftIo(struct raft *r, struct raft_event *event)
         goto err;
     }
 
+    if (r->legacy.prev_state != r->state) {
+        r->legacy.prev_state = r->state;
+    }
+
     /* Check if there's a client request in the completion queue which has
      * failed due to a RAFT_NOSPACE error. In that case we will not call the
      * step_cb just yet, because otherwise cowsql/dqlite would notice that

--- a/src/legacy.c
+++ b/src/legacy.c
@@ -575,7 +575,8 @@ int LegacyForwardToRaftIo(struct raft *r, struct raft_event *event)
         goto err;
     }
 
-    if (r->legacy.prev_state != r->state) {
+    if (update.flags & RAFT_UPDATE_STATE) {
+        assert(r->legacy.prev_state != r->state);
         if (r->legacy.prev_state == RAFT_LEADER) {
             LegacyFailPendingRequests(r);
             assert(QUEUE_IS_EMPTY(&r->legacy.pending));

--- a/src/legacy.h
+++ b/src/legacy.h
@@ -9,6 +9,9 @@
  * legacy raft_io interface. */
 int LegacyForwardToRaftIo(struct raft *r, struct raft_event *event);
 
+/* Fail all pending client requests with RAFT_LEADERSHIPLOST. */
+void LegacyFailPendingRequests(struct raft *r);
+
 /* Fire the callbacks of all completed client requests. */
 void LegacyFireCompletedRequests(struct raft *r);
 

--- a/src/membership.c
+++ b/src/membership.c
@@ -126,6 +126,8 @@ bool membershipUpdateCatchUpRound(struct raft *r)
         r->leader_state.round_index = 0;
         r->leader_state.round_start = 0;
 
+        progressCatchUpFinish(r, server_index);
+
         return true;
     }
 

--- a/src/progress.h
+++ b/src/progress.h
@@ -17,12 +17,13 @@ enum {
  */
 struct raft_progress
 {
-    unsigned short state;   /* Probe, pipeline or snapshot. */
-    raft_index next_index;  /* Next entry to send. */
-    raft_index match_index; /* Highest index reported as replicated. */
-    raft_time last_send;    /* Timestamp of last AppendEntries RPC. */
-    bool recent_recv;       /* A msg was received within election timeout. */
-    raft_flags features;    /* What the server is capable of. */
+    unsigned short state;    /* Probe, pipeline or snapshot. */
+    unsigned short catch_up; /* None, running, aborted, finished. */
+    raft_index next_index;   /* Next entry to send. */
+    raft_index match_index;  /* Highest index reported as replicated. */
+    raft_time last_send;     /* Timestamp of last AppendEntries RPC. */
+    bool recent_recv;        /* A msg was received within election timeout. */
+    raft_flags features;     /* What the server is capable of. */
     struct
     {
         raft_index index;    /* Last index of most recent snapshot sent. */
@@ -131,5 +132,18 @@ void progressSetFeatures(struct raft *r, const unsigned i, raft_flags features);
 
 /* Gets the feature flags of a node. */
 raft_flags progressGetFeatures(struct raft *r, const unsigned i);
+
+/* Start catching up a server. */
+void progressCatchUpStart(struct raft *r, unsigned i);
+
+/* Stop catching up a server because it's not fast enough or it's
+ * unresponsive. */
+void progressCatchUpAbort(struct raft *r, unsigned i);
+
+/* Stop catching up a server because it has now caught up. */
+void progressCatchUpFinish(struct raft *r, unsigned i);
+
+/* Return the information about the catch-up progress of a server. */
+int progressCatchUpStatus(struct raft *r, unsigned i);
 
 #endif /* PROGRESS_H_ */

--- a/src/raft.c
+++ b/src/raft.c
@@ -347,6 +347,10 @@ int raft_step(struct raft *r,
             rv = stepReceive(r, event->receive.id, event->receive.address,
                              event->receive.message);
             break;
+        case RAFT_CONFIGURATION:
+            rv = replicationApplyConfigurationChange(
+                r, event->configuration.index);
+            break;
         case RAFT_SNAPSHOT:
             rv = replicationSnapshot(r, &event->snapshot.metadata,
                                      event->snapshot.trailing);

--- a/src/raft.c
+++ b/src/raft.c
@@ -16,6 +16,7 @@
 #include "legacy.h"
 #include "log.h"
 #include "membership.h"
+#include "progress.h"
 #include "queue.h"
 #include "recv.h"
 #include "replication.h"
@@ -386,6 +387,24 @@ raft_term raft_current_term(struct raft *r)
 raft_term raft_voted_for(struct raft *r)
 {
     return r->voted_for;
+}
+
+int raft_catch_up(struct raft *r, raft_id id, int *status)
+{
+    unsigned i;
+
+    if (r->state != RAFT_LEADER) {
+        return RAFT_NOTLEADER;
+    }
+
+    i = configurationIndexOf(&r->configuration, id);
+    if (i == r->configuration.n) {
+        return RAFT_BADID;
+    }
+
+    *status = progressCatchUpStatus(r, i);
+
+    return 0;
 }
 
 void raft_set_election_timeout(struct raft *r, const unsigned msecs)

--- a/src/raft.c
+++ b/src/raft.c
@@ -115,6 +115,7 @@ int raft_init(struct raft *r,
         }
         r->now = r->io->time(r->io);
         raft_seed(r, (unsigned)r->io->random(r->io, 0, INT_MAX));
+        r->legacy.prev_state = r->state;
         QUEUE_INIT(&r->legacy.requests);
         r->legacy.step_cb = NULL;
     }

--- a/src/raft.c
+++ b/src/raft.c
@@ -390,6 +390,11 @@ raft_term raft_voted_for(struct raft *r)
     return r->voted_for;
 }
 
+raft_index raft_commit_index(struct raft *r)
+{
+    return r->commit_index;
+}
+
 int raft_catch_up(struct raft *r, raft_id id, int *status)
 {
     unsigned i;

--- a/src/raft.c
+++ b/src/raft.c
@@ -116,6 +116,7 @@ int raft_init(struct raft *r,
         r->now = r->io->time(r->io);
         raft_seed(r, (unsigned)r->io->random(r->io, 0, INT_MAX));
         r->legacy.prev_state = r->state;
+        QUEUE_INIT(&r->legacy.pending);
         QUEUE_INIT(&r->legacy.requests);
         r->legacy.step_cb = NULL;
     }
@@ -158,6 +159,7 @@ void raft_close(struct raft *r, void (*cb)(struct raft *r))
     if (r->state != RAFT_UNAVAILABLE) {
         convertToUnavailable(r);
         if (r->io != NULL) {
+            LegacyFailPendingRequests(r);
             LegacyFireCompletedRequests(r);
         }
     }

--- a/src/raft.c
+++ b/src/raft.c
@@ -121,6 +121,7 @@ int raft_init(struct raft *r,
         QUEUE_INIT(&r->legacy.requests);
         r->legacy.step_cb = NULL;
         r->legacy.change = NULL;
+        r->legacy.snapshot_index = 0;
     }
     r->update = NULL;
     r->messages = NULL;
@@ -235,6 +236,7 @@ static int stepStart(struct raft *r,
          * the first entry to be the same on all servers. */
         r->commit_index = 1;
         r->last_applied = 1;
+        r->update->flags |= RAFT_UPDATE_COMMIT_INDEX;
     }
 
     /* Append the entries to the log, possibly restoring the last

--- a/src/raft.c
+++ b/src/raft.c
@@ -120,6 +120,7 @@ int raft_init(struct raft *r,
         QUEUE_INIT(&r->legacy.pending);
         QUEUE_INIT(&r->legacy.requests);
         r->legacy.step_cb = NULL;
+        r->legacy.change = NULL;
     }
     r->update = NULL;
     r->messages = NULL;

--- a/src/replication.c
+++ b/src/replication.c
@@ -1340,8 +1340,8 @@ static void applyChange(struct raft *r, const raft_index index)
 
     if (r->state == RAFT_LEADER) {
         const struct raft_server *server;
-        req = r->leader_state.change;
-        r->leader_state.change = NULL;
+        req = r->legacy.change;
+        r->legacy.change = NULL;
 
         /* If we are leader but not part of this new configuration, step
          * down.

--- a/src/replication.c
+++ b/src/replication.c
@@ -370,7 +370,7 @@ static struct request *getRequest(struct raft *r,
     if (r->state != RAFT_LEADER) {
         return NULL;
     }
-    QUEUE_FOREACH (head, &r->leader_state.requests) {
+    QUEUE_FOREACH (head, &r->legacy.pending) {
         req = QUEUE_DATA(head, struct request, queue);
         if (req->index == index) {
             if (type != -1) {

--- a/src/replication.h
+++ b/src/replication.h
@@ -79,11 +79,6 @@ int replicationInstallSnapshot(struct raft *r,
 /* Returns `true` if the raft instance is currently installing a snapshot */
 bool replicationInstallSnapshotBusy(struct raft *r);
 
-/* Apply any committed entry that was not applied yet.
- *
- * It must be called by leaders or followers. */
-int replicationApply(struct raft *r);
-
 /* Check if a quorum has been reached for the given log index, and update the
  * commit index accordingly if so.
  *
@@ -125,5 +120,8 @@ int replicationPersistSnapshotDone(struct raft *r,
 int replicationSnapshot(struct raft *r,
                         struct raft_snapshot_metadata *metadata,
                         unsigned trailing);
+
+/* Apply a RAFT_CHANGE entry that has been committed. */
+int replicationApplyConfigurationChange(struct raft *r, raft_index index);
 
 #endif /* REPLICATION_H_ */

--- a/src/restore.c
+++ b/src/restore.c
@@ -139,6 +139,7 @@ int RestoreSnapshot(struct raft *r, struct raft_snapshot_metadata *metadata)
     r->commit_index = metadata->index;
     r->last_applied = metadata->index;
     r->last_stored = metadata->index;
+    r->update->flags |= RAFT_UPDATE_COMMIT_INDEX;
 
     return 0;
 }

--- a/src/tick.c
+++ b/src/tick.c
@@ -174,7 +174,6 @@ static int tickLeader(struct raft *r)
         if (is_too_slow || is_unresponsive) {
             tracef("server_index:%d is_too_slow:%d is_unresponsive:%d",
                    server_index, is_too_slow, is_unresponsive);
-            struct raft_change *change;
 
             r->leader_state.promotee_id = 0;
 
@@ -183,14 +182,6 @@ static int tickLeader(struct raft *r)
             r->leader_state.round_start = 0;
 
             progressCatchUpAbort(r, server_index);
-
-            change = r->legacy.change;
-            r->legacy.change = NULL;
-            if (change != NULL && change->cb != NULL) {
-                change->type = RAFT_CHANGE;
-                change->status = RAFT_NOCONNECTION;
-                QUEUE_PUSH(&r->legacy.requests, &change->queue);
-            }
         }
     }
 

--- a/src/tick.c
+++ b/src/tick.c
@@ -182,6 +182,8 @@ static int tickLeader(struct raft *r)
             r->leader_state.round_number = 0;
             r->leader_state.round_start = 0;
 
+            progressCatchUpAbort(r, server_index);
+
             change = r->leader_state.change;
             r->leader_state.change = NULL;
             if (change != NULL && change->cb != NULL) {

--- a/src/tick.c
+++ b/src/tick.c
@@ -184,8 +184,8 @@ static int tickLeader(struct raft *r)
 
             progressCatchUpAbort(r, server_index);
 
-            change = r->leader_state.change;
-            r->leader_state.change = NULL;
+            change = r->legacy.change;
+            r->legacy.change = NULL;
             if (change != NULL && change->cb != NULL) {
                 change->type = RAFT_CHANGE;
                 change->status = RAFT_NOCONNECTION;

--- a/test/integration/test_snapshot.c
+++ b/test/integration/test_snapshot.c
@@ -711,6 +711,11 @@ TEST(snapshot, unavailableDiscardsSnapshot, setUp, tearDown, 0, NULL)
     struct fixture *f = data;
     (void)params;
 
+    /* FIXME: this test uses raft_fixture_make_unavailable(), which is
+     * incompatible with the v1 API, since it calls convertToUnavailable()
+     * directly, bypassing raft_step(). */
+    return MUNIT_SKIP;
+
     /* Set very low threshold and trailing entries number */
     SET_SNAPSHOT_THRESHOLD(3);
     SET_SNAPSHOT_TRAILING(1);


### PR DESCRIPTION
This moves the client requests queue and associated code from the core raft struct to the compatibility layer.