### PR TITLE
docs: Use the 'styles' keyword instead of the deprecated 'style'

### DIFF
--- a/docs/_themes/material/layout.html
+++ b/docs/_themes/material/layout.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 
 {%- macro css() %}
-    <link rel="stylesheet" href="{{ pathto('_static/' + style, 1) }}" type="text/css" />
+    <link rel="stylesheet" href="{{ pathto('_static/' + styles[0], 1) }}" type="text/css" />
     {%- for css in css_files %}
       {%- if css|attr("filename") %}
     {{ css_tag(css) }}


### PR DESCRIPTION
The 'style' keyword has been long deprecated and finally removed in Sphynx 7.0.0.

See https://github.com/sphinx-doc/sphinx/pull/11381.