### PR TITLE
test: Start a server with no on-disk state using the V1 API

### DIFF
--- a/include/raft.h
+++ b/include/raft.h
@@ -534,7 +534,7 @@ struct raft_tracer_info
     union {
         struct
         {
-            int level;
+            int level; /* 1 Error, 2 Warning, 3 Info, 4 Debug, 5 Trace */
             const char *message;
             const char *file;
             int line;

--- a/include/raft.h
+++ b/include/raft.h
@@ -1116,6 +1116,11 @@ RAFT_API raft_id raft_voted_for(struct raft *r);
 RAFT_API raft_index raft_commit_index(struct raft *r);
 
 /**
+ * Return the time at which the next RAFT_TIMEOUT event should be fired.
+ */
+RAFT_API raft_time raft_timeout(struct raft *r);
+
+/**
  * Return information about the progress of a server that is catching up with
  * logs after a #RAFT_CATCH_UP event was fired.
  */

--- a/include/raft.h
+++ b/include/raft.h
@@ -580,9 +580,9 @@ enum {
  */
 struct raft_event
 {
+    raft_time time;
     unsigned char type;
     unsigned char reserved[7];
-    raft_time time;
     union {
         struct
         {

--- a/src/election.c
+++ b/src/election.c
@@ -50,6 +50,14 @@ bool electionTimerExpired(struct raft *r)
     return now - r->election_timer_start >= state->randomized_election_timeout;
 }
 
+raft_time electionTimerExpiration(struct raft *r)
+{
+    struct followerOrCandidateState *state;
+    assert(r->state == RAFT_FOLLOWER || r->state == RAFT_CANDIDATE);
+    state = getFollowerOrCandidateState(r);
+    return r->election_timer_start + state->randomized_election_timeout;
+}
+
 /* Send a RequestVote RPC to the given server. */
 static int electionSend(struct raft *r, const struct raft_server *server)
 {

--- a/src/election.h
+++ b/src/election.h
@@ -37,6 +37,11 @@ void electionResetTimer(struct raft *r);
  * Must be called in follower or candidate state. */
 bool electionTimerExpired(struct raft *r);
 
+/* Return the time at which the election timer will expire next.
+ *
+ * Must be called in follower or candidate state. */
+raft_time electionTimerExpiration(struct raft *r);
+
 /* Start a new election round.
  *
  * From Figure 3.1:

--- a/src/log.c
+++ b/src/log.c
@@ -656,6 +656,11 @@ raft_index logSnapshotIndex(struct raft_log *l)
     return l->snapshot.last_index;
 }
 
+raft_term logSnapshotTerm(struct raft_log *l)
+{
+    return l->snapshot.last_term;
+}
+
 raft_term logLastTerm(struct raft_log *l)
 {
     raft_index last_index;

--- a/src/log.h
+++ b/src/log.h
@@ -85,6 +85,10 @@ raft_term logTermOf(struct raft_log *l, raft_index index);
  * there are no snapshots. */
 raft_index logSnapshotIndex(struct raft_log *l);
 
+/* Get the term of the last entry of the most recent snapshot. Return #0 if
+ * there are no snapshots. */
+raft_term logSnapshotTerm(struct raft_log *l);
+
 /* Get the entry with the given index. * The returned pointer remains valid only
  * as long as no API that might delete the entry with the given index is
  * invoked. Return #NULL if there is no such entry. */

--- a/src/raft.c
+++ b/src/raft.c
@@ -401,6 +401,27 @@ raft_index raft_commit_index(struct raft *r)
     return r->commit_index;
 }
 
+raft_time raft_timeout(struct raft *r)
+{
+    raft_time timeout;
+    switch (r->state) {
+        case RAFT_FOLLOWER:
+            /* fallthrough */
+        case RAFT_CANDIDATE:
+            timeout = electionTimerExpiration(r);
+            break;
+        case RAFT_LEADER:
+            /* TODO: keep track of the last heartbeat timestamp */
+            timeout = r->now + r->heartbeat_timeout;
+            break;
+        default:
+            timeout = 0;
+            break;
+    }
+
+    return timeout;
+}
+
 int raft_catch_up(struct raft *r, raft_id id, int *status)
 {
     unsigned i;

--- a/src/raft.c
+++ b/src/raft.c
@@ -37,6 +37,8 @@
 
 #define tracef(...) Tracef(r->tracer, __VA_ARGS__)
 
+#define infof(...) Infof(r->tracer, "> " __VA_ARGS__)
+
 int raft_version_number(void)
 {
     return RAFT_VERSION_NUMBER;

--- a/src/tracing.h
+++ b/src/tracing.h
@@ -25,6 +25,9 @@ extern struct raft_tracer StderrTracer;
         }                                      \
     } while (0)
 
+/* Emit a diagnostic message with the given tracer at level 3. */
+#define Infof(TRACER, ...) Logf(TRACER, 3, __VA_ARGS__)
+
 /* Emit diagnostic message with the given tracer at level 5. */
 #define Tracef(TRACER, ...) Logf(TRACER, 5, __VA_ARGS__)
 

--- a/test/fuzzy/test_election.c
+++ b/test/fuzzy/test_election.c
@@ -27,7 +27,7 @@ static void *setup(const MunitParameter params[], MUNIT_UNUSED void *user_data)
     SETUP_CLUSTER(0);
     CLUSTER_BOOTSTRAP;
     CLUSTER_RANDOMIZE;
-    CLUSTER_START;
+    CLUSTER_START();
     return f;
 }
 

--- a/test/fuzzy/test_liveness.c
+++ b/test/fuzzy/test_liveness.c
@@ -82,7 +82,7 @@ static void *setup(const MunitParameter params[], MUNIT_UNUSED void *user_data)
     SETUP_CLUSTER(0);
     CLUSTER_BOOTSTRAP;
     CLUSTER_RANDOMIZE;
-    CLUSTER_START;
+    CLUSTER_START();
 
     /* Number of distinct pairs of servers. */
     pairs = __server_pairs(f);

--- a/test/fuzzy/test_membership.c
+++ b/test/fuzzy/test_membership.c
@@ -26,7 +26,7 @@ static void *setup(const MunitParameter params[], MUNIT_UNUSED void *user_data)
     SETUP_CLUSTER(0);
     CLUSTER_BOOTSTRAP;
     CLUSTER_RANDOMIZE;
-    CLUSTER_START;
+    CLUSTER_START();
     CLUSTER_STEP_UNTIL_HAS_LEADER(10000);
     return f;
 }

--- a/test/fuzzy/test_replication.c
+++ b/test/fuzzy/test_replication.c
@@ -25,7 +25,7 @@ static void *setup(const MunitParameter params[], MUNIT_UNUSED void *user_data)
     SETUP_CLUSTER(0);
     CLUSTER_BOOTSTRAP;
     CLUSTER_RANDOMIZE;
-    CLUSTER_START;
+    CLUSTER_START();
     CLUSTER_STEP_UNTIL_HAS_LEADER(10000);
     return f;
 }

--- a/test/integration/test_apply.c
+++ b/test/integration/test_apply.c
@@ -17,7 +17,7 @@ static void *setUp(const MunitParameter params[], MUNIT_UNUSED void *user_data)
     struct fixture *f = munit_malloc(sizeof *f);
     SETUP_CLUSTER(2);
     CLUSTER_BOOTSTRAP;
-    CLUSTER_START;
+    CLUSTER_START();
     CLUSTER_ELECT(0);
     return f;
 }

--- a/test/integration/test_assign.c
+++ b/test/integration/test_assign.c
@@ -110,7 +110,7 @@ static void *setUp(const MunitParameter params[], MUNIT_UNUSED void *user_data)
     struct fixture *f = munit_malloc(sizeof *f);
     SETUP_CLUSTER(2);
     CLUSTER_BOOTSTRAP;
-    CLUSTER_START;
+    CLUSTER_START();
     CLUSTER_ELECT(0);
     return f;
 }

--- a/test/integration/test_barrier.c
+++ b/test/integration/test_barrier.c
@@ -17,7 +17,7 @@ static void *setUp(const MunitParameter params[], MUNIT_UNUSED void *user_data)
     struct fixture *f = munit_malloc(sizeof *f);
     SETUP_CLUSTER(2);
     CLUSTER_BOOTSTRAP;
-    CLUSTER_START;
+    CLUSTER_START();
     CLUSTER_ELECT(0);
     return f;
 }

--- a/test/integration/test_bootstrap.c
+++ b/test/integration/test_bootstrap.c
@@ -45,7 +45,7 @@ TEST(raft_bootstrap, busy, setUp, tearDown, 0, NULL)
 
     /* Bootstrap and the first server. */
     CLUSTER_BOOTSTRAP_N_VOTING(1);
-    CLUSTER_START;
+    CLUSTER_START();
 
     raft = CLUSTER_RAFT(0);
     CLUSTER_CONFIGURATION(&configuration);

--- a/test/integration/test_election.c
+++ b/test/integration/test_election.c
@@ -112,7 +112,7 @@ TEST(election, twoVoters, setUp, tearDown, 0, NULL)
 {
     struct fixture *f = data;
     (void)params;
-    CLUSTER_START;
+    CLUSTER_START();
 
     /* The first server eventually times out and converts to candidate. */
     STEP_UNTIL_CANDIDATE(0);
@@ -142,7 +142,7 @@ TEST(election, grantAgain, setUp, tearDown, 0, NULL)
     (void)params;
     raft_fixture_set_randomized_election_timeout(&f->cluster, 1, 10000);
     raft_set_election_timeout(CLUSTER_RAFT(1), 10000);
-    CLUSTER_START;
+    CLUSTER_START();
 
     /* The first server converts to candidate. */
     STEP_UNTIL_CANDIDATE(0);
@@ -187,7 +187,7 @@ TEST(election, grantIfLastIndexIsSame, setUp, tearDown, 0, NULL)
     CLUSTER_ADD_ENTRY(1, &entry2);
     CLUSTER_SET_TERM(1, 2);
 
-    CLUSTER_START;
+    CLUSTER_START();
 
     /* The first server converts to candidate. */
     STEP_UNTIL_CANDIDATE(0);
@@ -214,7 +214,7 @@ TEST(election, grantIfLastIndexIsHigher, setUp, tearDown, 0, NULL)
     CLUSTER_ADD_ENTRY(0, &entry);
     CLUSTER_SET_TERM(1, 2);
 
-    CLUSTER_START;
+    CLUSTER_START();
 
     /* The first server converts to candidate. */
     STEP_UNTIL_CANDIDATE(0);
@@ -236,7 +236,7 @@ TEST(election, waitQuorum, setUp, tearDown, 0, cluster_5_params)
 {
     struct fixture *f = data;
     (void)params;
-    CLUSTER_START;
+    CLUSTER_START();
 
     /* The first server converts to candidate. */
     STEP_UNTIL_CANDIDATE(0);
@@ -270,7 +270,7 @@ TEST(election, rejectIfHigherTerm, setUp, tearDown, 0, NULL)
     (void)params;
 
     CLUSTER_SET_TERM(1, 3);
-    CLUSTER_START;
+    CLUSTER_START();
 
     /* The first server converts to candidate. */
     STEP_UNTIL_CANDIDATE(0);
@@ -296,7 +296,7 @@ TEST(election, rejectIfHasLeader, setUp, tearDown, 0, cluster_3_params)
 {
     struct fixture *f = data;
     (void)params;
-    CLUSTER_START;
+    CLUSTER_START();
 
     /* Server 0 wins the elections. */
     STEP_UNTIL_LEADER(0);
@@ -324,7 +324,7 @@ TEST(election, rejectIfAlreadyVoted, setUp, tearDown, 0, cluster_3_params)
     raft_fixture_set_randomized_election_timeout(&f->cluster, 1, 1000);
     CLUSTER_SATURATE_BOTHWAYS(0, 1);
 
-    CLUSTER_START;
+    CLUSTER_START();
 
     /* Server 0 and server 1 both become candidates. */
     STEP_UNTIL_CANDIDATE(0);
@@ -365,7 +365,7 @@ TEST(election, rejectIfLastTermIsLower, setUp, tearDown, 0, NULL)
     CLUSTER_ADD_ENTRY(0, &entry1);
     CLUSTER_ADD_ENTRY(1, &entry2);
 
-    CLUSTER_START;
+    CLUSTER_START();
 
     /* The first server becomes candidate. */
     STEP_UNTIL_CANDIDATE(0);
@@ -404,7 +404,7 @@ TEST(election, rejectIfLastIndexIsLower, setUp, tearDown, 0, NULL)
 
     CLUSTER_ADD_ENTRY(1, &entry);
 
-    CLUSTER_START;
+    CLUSTER_START();
 
     /* The first server becomes candidate. */
     STEP_UNTIL_CANDIDATE(0);
@@ -447,7 +447,7 @@ TEST(election, rejectIfNotVoter, setUp, tearDown, 0, reject_not_voting_params)
      * (since there are only 2 voting servers). */
     CLUSTER_SATURATE_BOTHWAYS(0, 1);
 
-    CLUSTER_START;
+    CLUSTER_START();
 
     /* Server 0 becomes candidate. */
     STEP_UNTIL_CANDIDATE(0);
@@ -483,7 +483,7 @@ TEST(election, receiveRejectResult, setUp, tearDown, 0, cluster_5_params)
     CLUSTER_SATURATE_BOTHWAYS(4, 2);
     CLUSTER_SATURATE_BOTHWAYS(4, 3);
 
-    CLUSTER_START;
+    CLUSTER_START();
 
     /* The server 0 becomes candidate, server 4 one is still follower. */
     STEP_UNTIL_CANDIDATE(0);
@@ -528,7 +528,7 @@ TEST(election, ioErrorConvert, setUp, tearDown, 0, ioErrorConvert)
     struct fixture *f = data;
     const char *delay = munit_parameters_get(params, "delay");
     return MUNIT_SKIP;
-    CLUSTER_START;
+    CLUSTER_START();
 
     /* The first server fails to convert to candidate. */
     CLUSTER_IO_FAULT(0, atoi(delay), 1);
@@ -543,7 +543,7 @@ TEST(election, ioErrorSendVoteRequest, setUp, tearDown, 0, NULL)
 {
     struct fixture *f = data;
     return MUNIT_SKIP;
-    CLUSTER_START;
+    CLUSTER_START();
 
     /* The first server fails to send a RequestVote RPC. */
     CLUSTER_IO_FAULT(0, 2, 1);
@@ -561,7 +561,7 @@ TEST(election, ioErrorPersistVote, setUp, tearDown, 0, NULL)
 {
     struct fixture *f = data;
     return MUNIT_SKIP;
-    CLUSTER_START;
+    CLUSTER_START();
 
     /* The first server becomes candidate. */
     CLUSTER_STEP;
@@ -582,7 +582,7 @@ TEST(election, preVote, setUp, tearDown, 0, NULL)
     struct fixture *f = data;
     raft_set_pre_vote(CLUSTER_RAFT(0), true);
     raft_set_pre_vote(CLUSTER_RAFT(1), true);
-    CLUSTER_START;
+    CLUSTER_START();
 
     /* The first server eventually times out and converts to candidate, but it
      * does not increment its term yet.*/
@@ -624,7 +624,7 @@ TEST(election, preVoteWithcandidateCrash, setUp, tearDown, 0, cluster_3_params)
     raft_set_pre_vote(CLUSTER_RAFT(0), true);
     raft_set_pre_vote(CLUSTER_RAFT(1), true);
     raft_set_pre_vote(CLUSTER_RAFT(2), true);
-    CLUSTER_START;
+    CLUSTER_START();
 
     /* The first server eventually times out and converts to candidate, but it
      * does not increment its term yet.*/
@@ -719,7 +719,7 @@ TEST(election, preVoteNoStaleVotes, setUp, tearDown, 0, cluster_3_params)
     /* Server 2 is 1 term ahead of the other servers, this will allow it to send
      * stale pre-vote responses that pass the term checks. */
     CLUSTER_SET_TERM(2, 2);
-    CLUSTER_START;
+    CLUSTER_START();
 
     /* The first server eventually times out and converts to candidate, but it
      * does not increment its term yet.*/
@@ -812,7 +812,7 @@ TEST(election,
     CLUSTER_SATURATE(0, 1);
     CLUSTER_SATURATE(1, 0);
 
-    CLUSTER_START;
+    CLUSTER_START();
 
     /* Server 0 wins elections for term 2, with vote from server 2. */
     CLUSTER_STEP_UNTIL_HAS_LEADER(1500);

--- a/test/integration/test_membership.c
+++ b/test/integration/test_membership.c
@@ -21,7 +21,7 @@ static void *setup(const MunitParameter params[], MUNIT_UNUSED void *user_data)
     struct fixture *f = munit_malloc(sizeof *f);
     SETUP_CLUSTER(2);
     CLUSTER_BOOTSTRAP;
-    CLUSTER_START;
+    CLUSTER_START();
     CLUSTER_ELECT(0);
     return f;
 }

--- a/test/integration/test_recover.c
+++ b/test/integration/test_recover.c
@@ -44,7 +44,7 @@ TEST(raft_recover, busy, setUp, tearDown, 0, NULL)
     int rv;
 
     /* Start all servers. */
-    CLUSTER_START;
+    CLUSTER_START();
 
     raft = CLUSTER_RAFT(0);
     CLUSTER_CONFIGURATION(&configuration);

--- a/test/integration/test_replication.c
+++ b/test/integration/test_replication.c
@@ -24,7 +24,7 @@ struct fixture
 /* Standard startup sequence, bootstrapping the cluster and electing server 0 */
 #define BOOTSTRAP_START_AND_ELECT \
     CLUSTER_BOOTSTRAP;            \
-    CLUSTER_START;                \
+    CLUSTER_START();              \
     CLUSTER_ELECT(0);             \
     ASSERT_TIME(1045)
 
@@ -98,7 +98,7 @@ TEST(replication, sendInitialHeartbeat, setUp, tearDown, 0, NULL)
     struct fixture *f = data;
     struct raft *raft;
     CLUSTER_BOOTSTRAP;
-    CLUSTER_START;
+    CLUSTER_START();
 
     /* Server 0 becomes candidate and sends vote requests after the election
      * timeout. */
@@ -134,7 +134,7 @@ TEST(replication, receiveFlags, setUp, tearDown, 0, NULL)
     struct fixture *f = data;
     struct raft *raft;
     CLUSTER_BOOTSTRAP;
-    CLUSTER_START;
+    CLUSTER_START();
 
     /* Server 0 becomes leader and sends the initial heartbeat. */
     CLUSTER_STEP_N(24);
@@ -168,7 +168,7 @@ TEST(replication, sendFollowupHeartbeat, setUp, tearDown, 0, NULL)
     struct fixture *f = data;
     struct raft *raft;
     CLUSTER_BOOTSTRAP;
-    CLUSTER_START;
+    CLUSTER_START();
 
     /* Server 0 becomes leader and sends the initial heartbeat. */
     CLUSTER_STEP_N(24);
@@ -212,7 +212,7 @@ TEST(replication, sendSkipHeartbeat, setUp, tearDown, 0, NULL)
     struct raft *raft;
     struct raft_apply req;
     CLUSTER_BOOTSTRAP;
-    CLUSTER_START;
+    CLUSTER_START();
 
     raft = CLUSTER_RAFT(0);
 
@@ -266,7 +266,7 @@ TEST(replication, sendProbe, setUp, tearDown, 0, NULL)
     struct raft_apply req1;
     struct raft_apply req2;
     CLUSTER_BOOTSTRAP;
-    CLUSTER_START;
+    CLUSTER_START();
 
     /* Server 0 becomes leader and sends the initial heartbeat. */
     CLUSTER_STEP_N(25);
@@ -323,7 +323,7 @@ TEST(replication, sendPipeline, setUp, tearDown, 0, NULL)
     struct raft_apply req1;
     struct raft_apply req2;
     CLUSTER_BOOTSTRAP;
-    CLUSTER_START;
+    CLUSTER_START();
 
     raft = CLUSTER_RAFT(0);
 
@@ -367,7 +367,7 @@ TEST(replication, sendDisconnect, setUp, tearDown, 0, NULL)
 {
     struct fixture *f = data;
     CLUSTER_BOOTSTRAP;
-    CLUSTER_START;
+    CLUSTER_START();
 
     /* Server 0 becomes leader and sends the initial heartbeat, however they
      * fail because server 1 has disconnected. */
@@ -399,7 +399,7 @@ TEST(replication, sendDisconnectPipeline, setUp, tearDown, 0, NULL)
     struct raft_apply req1;
     struct raft_apply req2;
     CLUSTER_BOOTSTRAP;
-    CLUSTER_START;
+    CLUSTER_START();
 
     /* Server 0 becomes leader and sends a couple of heartbeats. */
     CLUSTER_STEP_UNTIL_ELAPSED(1215);
@@ -539,7 +539,7 @@ TEST(replication, recvMissingEntries, setUp, tearDown, 0, NULL)
     CLUSTER_ADD_ENTRY(0, &entry);
 
     /* Server 0 wins the election because it has a longer log. */
-    CLUSTER_START;
+    CLUSTER_START();
     CLUSTER_STEP_UNTIL_HAS_LEADER(5000);
     munit_assert_int(CLUSTER_LEADER, ==, 0);
 
@@ -570,7 +570,7 @@ TEST(replication, recvPrevLogTermMismatch, setUp, tearDown, 0, NULL)
     FsmEncodeSetX(2, &entry2.buf);
     CLUSTER_ADD_ENTRY(1, &entry2);
 
-    CLUSTER_START;
+    CLUSTER_START();
     CLUSTER_ELECT(0);
 
     /* The follower eventually replicates the entry */
@@ -612,7 +612,7 @@ TEST(replication, recvRollbackConfigurationToInitial, setUp, tearDown, 0, NULL)
      * one contained in the entry that we just added. The server can't know yet
      * if it's committed or not, and regards it as pending configuration
      * change. */
-    CLUSTER_START;
+    CLUSTER_START();
     ASSERT_CONFIGURATION(1, &conf);
 
     /* The first server gets elected. */
@@ -678,7 +678,7 @@ TEST(replication, recvRollbackConfigurationToPrevious, setUp, tearDown, 0, NULL)
     /* At startup the second server uses the most recent configuration, i.e. the
      * one contained in the log entry at index 3. The server can't know yet if
      * it's committed or not, and regards it as pending configuration change. */
-    CLUSTER_START;
+    CLUSTER_START();
     ASSERT_CONFIGURATION(1, &conf);
 
     /* The first server gets elected. */
@@ -748,7 +748,7 @@ TEST(replication, recvRollbackConfigurationToSnapshot, setUp, tearDown, 0, NULL)
     /* At startup the second server uses the most recent configuration, i.e. the
      * one contained in the log entry at index 2. The server can't know yet if
      * it's committed or not, and regards it as pending configuration change. */
-    CLUSTER_START;
+    CLUSTER_START();
     ASSERT_CONFIGURATION(1, &conf);
 
     CLUSTER_ELECT(0);
@@ -788,7 +788,7 @@ TEST(replication, recvPrevIndexConflict, setUp, tearDown, 0, NULL)
     FsmEncodeSetX(2, &entry2.buf);
     CLUSTER_ADD_ENTRY(1, &entry2);
 
-    CLUSTER_START;
+    CLUSTER_START();
     CLUSTER_ELECT(0);
 
     /* Artificially bump the commit index on the second server */
@@ -855,7 +855,7 @@ TEST(replication, recvMatch_last_snapshot, setUp, tearDown, 0, NULL)
                          0 /* y                                             */);
     CLUSTER_SET_TERM(1, 2);
 
-    CLUSTER_START;
+    CLUSTER_START();
     CLUSTER_ELECT(0);
 
     /* Apply an additional entry and check that it gets replicated on the
@@ -882,7 +882,7 @@ TEST(replication, recvCandidateSameTerm, setUp, tearDown, 0, NULL)
     raft_set_election_timeout(CLUSTER_RAFT(2), 800);
 
     /* Server 2 becomes candidate. */
-    CLUSTER_START;
+    CLUSTER_START();
     CLUSTER_STEP_UNTIL_STATE_IS(2, RAFT_CANDIDATE, 1000);
     munit_assert_int(CLUSTER_TERM(2), ==, 2);
 
@@ -928,7 +928,7 @@ TEST(replication, recvCandidateHigherTerm, setUp, tearDown, 0, NULL)
     raft_set_election_timeout(CLUSTER_RAFT(0), 800);
     CLUSTER_SATURATE_BOTHWAYS(0, 1);
 
-    CLUSTER_START;
+    CLUSTER_START();
 
     /* Server 2 becomes candidate, and server 0 already is candidate. */
     CLUSTER_STEP_UNTIL_STATE_IS(2, RAFT_CANDIDATE, 1500);
@@ -1062,7 +1062,7 @@ TEST(replication, resultRetry, setUp, tearDown, 0, NULL)
     FsmEncodeSetX(5, &entry.buf);
     CLUSTER_ADD_ENTRY(0, &entry);
 
-    CLUSTER_START;
+    CLUSTER_START();
     CLUSTER_ELECT(0);
 
     /* The first server receives an AppendEntries result from the second server
@@ -1202,7 +1202,7 @@ TEST(replication, failPersistBarrier, setUp, tearDown, 0, NULL)
 
     /* Server 0 gets elected and creates a barrier entry at index 2 */
     CLUSTER_BOOTSTRAP;
-    CLUSTER_START;
+    CLUSTER_START();
     CLUSTER_START_ELECT(0);
 
     /* Cluster recovers. */

--- a/test/integration/test_snapshot.c
+++ b/test/integration/test_snapshot.c
@@ -17,7 +17,7 @@ static void *setUp(const MunitParameter params[], MUNIT_UNUSED void *user_data)
     struct fixture *f = munit_malloc(sizeof *f);
     SETUP_CLUSTER(3);
     CLUSTER_BOOTSTRAP;
-    CLUSTER_START;
+    CLUSTER_START();
     CLUSTER_ELECT(0);
     return f;
 }

--- a/test/integration/test_start.c
+++ b/test/integration/test_start.c
@@ -73,7 +73,7 @@ TEST(raft_start, oneSnapshotAndNoEntries, setUp, tearDown, 0, NULL)
                          7 /* y                                             */);
     CLUSTER_SET_TERM(0, 2);
     BOOTSTRAP(1);
-    CLUSTER_START;
+    CLUSTER_START();
     CLUSTER_MAKE_PROGRESS;
     return MUNIT_OK;
 }
@@ -107,7 +107,7 @@ TEST(raft_start, oneSnapshotAndSomeFollowUpEntries, setUp, tearDown, 0, NULL)
     CLUSTER_ADD_ENTRY(1, &entries[1]);
     CLUSTER_SET_TERM(0, 2);
 
-    CLUSTER_START;
+    CLUSTER_START();
     CLUSTER_MAKE_PROGRESS;
 
     fsm = CLUSTER_FSM(0);
@@ -130,7 +130,7 @@ TEST(raft_start, noEntries, setUp, tearDown, 0, NULL)
     CLUSTER_GROW;
     BOOTSTRAP(1);
     BOOTSTRAP(2);
-    CLUSTER_START;
+    CLUSTER_START();
     CLUSTER_MAKE_PROGRESS;
     return MUNIT_OK;
 }
@@ -163,7 +163,7 @@ TEST(raft_start, twoEntries, setUp, tearDown, 0, NULL)
     BOOTSTRAP(1);
     BOOTSTRAP(2);
 
-    CLUSTER_START;
+    CLUSTER_START();
     CLUSTER_ELECT(0);
     CLUSTER_MAKE_PROGRESS;
 
@@ -183,7 +183,7 @@ TEST(raft_start, singleVotingSelfElect, setUp, tearDown, 0, NULL)
 {
     struct fixture *f = data;
     CLUSTER_BOOTSTRAP;
-    CLUSTER_START;
+    CLUSTER_START();
     munit_assert_int(CLUSTER_STATE(0), ==, RAFT_LEADER);
     CLUSTER_MAKE_PROGRESS;
     return MUNIT_OK;
@@ -196,7 +196,7 @@ TEST(raft_start, singleVotingNotUs, setUp, tearDown, 0, NULL)
     struct fixture *f = data;
     CLUSTER_GROW;
     CLUSTER_BOOTSTRAP_N_VOTING(1);
-    CLUSTER_START;
+    CLUSTER_START();
     munit_assert_int(CLUSTER_STATE(1), ==, RAFT_FOLLOWER);
     CLUSTER_MAKE_PROGRESS;
     return MUNIT_OK;

--- a/test/integration/test_start.c
+++ b/test/integration/test_start.c
@@ -59,6 +59,15 @@ static void tearDown(void *data)
 
 SUITE(raft_start)
 
+/* Start a server that has no persisted state whatsoever. */
+TEST_V1(raft_start, noState, setUp, tearDown, 0, NULL)
+{
+    struct fixture *f = data;
+    CLUSTER_START(1);
+    CLUSTER_TRACE("[   0] 1 > term 0, vote 0, no snapshot, no entries\n");
+    return MUNIT_OK;
+}
+
 /* There are two servers. The first has a snapshot present and no other
  * entries. */
 TEST(raft_start, oneSnapshotAndNoEntries, setUp, tearDown, 0, NULL)

--- a/test/integration/test_tick.c
+++ b/test/integration/test_tick.c
@@ -23,7 +23,7 @@ static void *setUp(const MunitParameter params[], MUNIT_UNUSED void *user_data)
     }
     SETUP_CLUSTER(n);
     CLUSTER_BOOTSTRAP_N_VOTING(n_voting);
-    CLUSTER_START;
+    CLUSTER_START();
     return f;
 }
 

--- a/test/integration/test_transfer.c
+++ b/test/integration/test_transfer.c
@@ -74,7 +74,7 @@ static void *setUp(const MunitParameter params[], MUNIT_UNUSED void *user_data)
     struct fixture *f = munit_malloc(sizeof *f);
     SETUP_CLUSTER(3);
     CLUSTER_BOOTSTRAP;
-    CLUSTER_START;
+    CLUSTER_START();
     CLUSTER_ELECT(0);
     return f;
 }

--- a/test/lib/cluster.h
+++ b/test/lib/cluster.h
@@ -189,7 +189,7 @@ static bool v1 = false;
     }
 
 /* Start all servers in the test cluster. */
-#define CLUSTER_START                         \
+#define CLUSTER_START()                       \
     {                                         \
         int rc;                               \
         rc = raft_fixture_start(&f->cluster); \

--- a/test/lib/cluster.h
+++ b/test/lib/cluster.h
@@ -16,6 +16,20 @@
 
 static bool v1 = false;
 
+#define TEST_V1(S, C, SETUP, TEAR_DOWN, OPTIONS, PARAMS)         \
+    static void *setUp__##S##_##C(const MunitParameter params[], \
+                                  void *user_data)               \
+    {                                                            \
+        v1 = true;                                               \
+        return SETUP(params, user_data);                         \
+    }                                                            \
+    static void tearDown__##S##_##C(void *data)                  \
+    {                                                            \
+        TEAR_DOWN(data);                                         \
+        v1 = false;                                              \
+    }                                                            \
+    TEST(S, C, setUp__##S##_##C, tearDown__##S##_##C, OPTIONS, PARAMS)
+
 #define FIXTURE_CLUSTER                                     \
     FIXTURE_HEAP;                                           \
     union {                                                 \

--- a/test/lib/cluster.h
+++ b/test/lib/cluster.h
@@ -188,13 +188,29 @@ static bool v1 = false;
         raft_configuration_close(&configuration_);                         \
     }
 
+/* Start the server with the given ID, using the state persisted on its disk. */
+#define CLUSTER_START_V1(ID) test_cluster_start(&f->cluster_, ID)
+
 /* Start all servers in the test cluster. */
-#define CLUSTER_START()                       \
+#define CLUSTER_START_V0()                    \
     {                                         \
         int rc;                               \
         rc = raft_fixture_start(&f->cluster); \
         munit_assert_int(rc, ==, 0);          \
     }
+
+#define FUNC_CHOOSER(_f1, _f2, ...) _f2
+#define FUNC_RECOMPOSER(argsWithParentheses) FUNC_CHOOSER argsWithParentheses
+
+#define CLUSTER_START__ARG_COUNT(...) \
+    FUNC_RECOMPOSER((__VA_ARGS__, CLUSTER_START_V1, ))
+
+#define CLUSTER_START__NO_ARG() , CLUSTER_START_V0
+
+#define CLUSTER_START__CHOOSER(...) \
+    CLUSTER_START__ARG_COUNT(CLUSTER_START__NO_ARG __VA_ARGS__())
+
+#define CLUSTER_START(...) CLUSTER_START__CHOOSER(__VA_ARGS__)(__VA_ARGS__)
 
 /* Step the cluster. */
 #define CLUSTER_STEP raft_fixture_step(&f->cluster);

--- a/test/lib/cluster.h
+++ b/test/lib/cluster.h
@@ -505,4 +505,8 @@ struct test_cluster
 void test_cluster_setup(const MunitParameter params[], struct test_cluster *c);
 void test_cluster_tear_down(struct test_cluster *c);
 
+/* Start the server with the given @id, using the current state persisted on its
+ * disk. */
+void test_cluster_start(struct test_cluster *c, raft_id id);
+
 #endif /* TEST_CLUSTER_H */

--- a/test/lib/cluster.h
+++ b/test/lib/cluster.h
@@ -212,6 +212,11 @@ static bool v1 = false;
 
 #define CLUSTER_START(...) CLUSTER_START__CHOOSER(__VA_ARGS__)(__VA_ARGS__)
 
+#define CLUSTER_TRACE(EXPECTED)                        \
+    if (!test_cluster_trace(&f->cluster_, EXPECTED)) { \
+        munit_error("trace does not match");           \
+    }
+
 /* Step the cluster. */
 #define CLUSTER_STEP raft_fixture_step(&f->cluster);
 
@@ -524,5 +529,10 @@ void test_cluster_tear_down(struct test_cluster *c);
 /* Start the server with the given @id, using the current state persisted on its
  * disk. */
 void test_cluster_start(struct test_cluster *c, raft_id id);
+
+/* Compare the trace of all messages emitted by all servers with the given
+ * expected trace. If they don't match, print the last line which differs and
+ * return #false. */
+bool test_cluster_trace(struct test_cluster *c, const char *expected);
 
 #endif /* TEST_CLUSTER_H */


### PR DESCRIPTION
This is a proof-of-concept test case that starts a single server with no persisted state.