### PR TITLE
test: Add `test_cluster_step()` helper

### DIFF
--- a/include/raft.h
+++ b/include/raft.h
@@ -1443,6 +1443,16 @@ RAFT_API int raft_transfer(struct raft *r,
 RAFT_API unsigned raft_random(unsigned *state, unsigned min, unsigned max);
 
 /**
+ * Return the name of state with the given code.
+ */
+RAFT_API const char *raft_state_name(int state);
+
+/**
+ * Return the name of role with the given code.
+ */
+RAFT_API const char *raft_role_name(int state);
+
+/**
  * User-definable dynamic memory allocation functions.
  *
  * The @data field will be passed as first argument to all functions.

--- a/include/raft.h
+++ b/include/raft.h
@@ -1437,6 +1437,12 @@ RAFT_API int raft_transfer(struct raft *r,
                            raft_transfer_cb cb);
 
 /**
+ * Generate a pseudo-random number between @min and @max, using @state as
+ * generator state.
+ */
+RAFT_API unsigned raft_random(unsigned *state, unsigned min, unsigned max);
+
+/**
  * User-definable dynamic memory allocation functions.
  *
  * The @data field will be passed as first argument to all functions.

--- a/include/raft.h
+++ b/include/raft.h
@@ -679,6 +679,7 @@ struct raft_update
 #define RAFT_UPDATE_MESSAGES 1 << 4
 #define RAFT_UPDATE_STATE 1 << 5
 #define RAFT_UPDATE_COMMIT_INDEX 1 << 6
+#define RAFT_UPDATE_TIMEOUT 1 << 7
 
 /**
  * version field MUST be filled out by user.

--- a/src/convert.c
+++ b/src/convert.c
@@ -142,6 +142,7 @@ int convertToLeader(struct raft *r)
 
     /* Reset timers */
     r->election_timer_start = r->now;
+    r->update->flags |= RAFT_UPDATE_TIMEOUT;
 
     /* Allocate and initialize the progress array. */
     rv = progressBuildArray(r);

--- a/src/election.c
+++ b/src/election.c
@@ -41,6 +41,7 @@ void electionResetTimer(struct raft *r)
     assert(timeout <= r->election_timeout * 2);
     state->randomized_election_timeout = timeout;
     r->election_timer_start = r->now;
+    r->update->flags |= RAFT_UPDATE_TIMEOUT;
 }
 
 bool electionTimerExpired(struct raft *r)
@@ -271,6 +272,7 @@ grant_vote:
 
         /* Reset the election timer. */
         r->election_timer_start = r->now;
+        r->update->flags |= RAFT_UPDATE_TIMEOUT;
     }
 
     tracef("vote granted to %llu", args->candidate_id);

--- a/src/raft.c
+++ b/src/raft.c
@@ -608,6 +608,49 @@ unsigned raft_random(unsigned *state, unsigned min, unsigned max)
     return RandomWithinRange(state, min, max);
 }
 
+const char *raft_state_name(int state)
+{
+    const char *name;
+    switch (state) {
+        case RAFT_UNAVAILABLE:
+            name = "unavailable";
+            break;
+        case RAFT_FOLLOWER:
+            name = "follower";
+            break;
+        case RAFT_CANDIDATE:
+            name = "candidate";
+            break;
+        case RAFT_LEADER:
+            name = "leader";
+            break;
+        default:
+            name = NULL;
+            break;
+    }
+    return name;
+}
+
+const char *raft_role_name(int role)
+{
+    const char *name;
+    switch (role) {
+        case RAFT_STANDBY:
+            name = "stand-by";
+            break;
+        case RAFT_VOTER:
+            name = "voter";
+            break;
+        case RAFT_SPARE:
+            name = "spare";
+            break;
+        default:
+            name = NULL;
+            break;
+    }
+    return name;
+}
+
 static int ioFsmVersionCheck(struct raft *r,
                              struct raft_io *io,
                              struct raft_fsm *fsm)

--- a/src/raft.c
+++ b/src/raft.c
@@ -389,6 +389,7 @@ int raft_step(struct raft *r,
                                      event->snapshot.trailing);
             break;
         case RAFT_TIMEOUT:
+            infof("timeout as %s", raft_state_name(r->state));
             rv = Tick(r);
             break;
         case RAFT_SUBMIT:

--- a/src/raft.c
+++ b/src/raft.c
@@ -18,6 +18,7 @@
 #include "membership.h"
 #include "progress.h"
 #include "queue.h"
+#include "random.h"
 #include "recv.h"
 #include "replication.h"
 #include "restore.h"
@@ -600,6 +601,11 @@ unsigned long long raft_digest(const char *text, unsigned long long n)
     memcpy(&digest, value + (sizeof value - sizeof digest), sizeof digest);
 
     return byteFlip64(digest);
+}
+
+unsigned raft_random(unsigned *state, unsigned min, unsigned max)
+{
+    return RandomWithinRange(state, min, max);
 }
 
 static int ioFsmVersionCheck(struct raft *r,

--- a/src/recv_append_entries.c
+++ b/src/recv_append_entries.c
@@ -105,6 +105,7 @@ int recvAppendEntries(struct raft *r,
 
     /* Reset the election timer. */
     r->election_timer_start = r->now;
+    r->update->flags |= RAFT_UPDATE_TIMEOUT;
 
     /* If we are installing a snapshot, ignore these entries. TODO: we should do
      * something smarter, e.g. buffering the entries in the I/O backend, which

--- a/src/recv_install_snapshot.c
+++ b/src/recv_install_snapshot.c
@@ -58,6 +58,7 @@ int recvInstallSnapshot(struct raft *r,
         return rv;
     }
     r->election_timer_start = r->now;
+    r->update->flags |= RAFT_UPDATE_TIMEOUT;
 
     rv = replicationInstallSnapshot(r, args, &result->rejected, &async);
     if (rv != 0) {

--- a/src/tick.c
+++ b/src/tick.c
@@ -135,6 +135,7 @@ static int tickLeader(struct raft *r)
             return 0;
         }
         r->election_timer_start = r->now;
+        r->update->flags |= RAFT_UPDATE_TIMEOUT;
     }
 
     /* Possibly send heartbeats.

--- a/src/tick.c
+++ b/src/tick.c
@@ -12,6 +12,8 @@
 
 #define tracef(...) Tracef(r->tracer, __VA_ARGS__)
 
+#define infof(...) Infof(r->tracer, "  " __VA_ARGS__)
+
 /* Apply time-dependent rules for followers (Figure 3.1). */
 static int tickFollower(struct raft *r)
 {
@@ -26,6 +28,7 @@ static int tickFollower(struct raft *r)
     /* If we have been removed from the configuration, or maybe we didn't
      * receive one yet, just stay follower. */
     if (server == NULL) {
+        infof("server not in current configuration -> stay follower");
         return 0;
     }
 

--- a/src/tick.c
+++ b/src/tick.c
@@ -45,11 +45,14 @@ static int tickFollower(struct raft *r)
      *   If election timeout elapses without receiving AppendEntries RPC from
      *   current leader or granting vote to candidate, convert to candidate.
      */
-    if (electionTimerExpired(r) && server->role == RAFT_VOTER) {
+    if (electionTimerExpired(r)) {
+        if (server->role != RAFT_VOTER) {
+            goto out;
+        }
         if (replicationInstallSnapshotBusy(r)) {
             tracef("installing snapshot -> don't convert to candidate");
             electionResetTimer(r);
-            return 0;
+            goto out;
         }
         tracef("convert to candidate and start new election");
         rv = convertToCandidate(r, false /* disrupt leader */);
@@ -59,6 +62,7 @@ static int tickFollower(struct raft *r)
         }
     }
 
+out:
     return 0;
 }
 

--- a/test/integration/test_start.c
+++ b/test/integration/test_start.c
@@ -65,6 +65,7 @@ TEST_V1(raft_start, noState, setUp, tearDown, 0, NULL)
     struct fixture *f = data;
     CLUSTER_START(1);
     CLUSTER_TRACE("[   0] 1 > term 0, vote 0, no snapshot, no entries\n");
+    munit_assert_int(raft_timeout(CLUSTER_RAFT(1)), ==, 100);
     return MUNIT_OK;
 }
 

--- a/test/integration/test_tick.c
+++ b/test/integration/test_tick.c
@@ -22,8 +22,10 @@ static void *setUp(const MunitParameter params[], MUNIT_UNUSED void *user_data)
         n_voting = atoi(n_voting_param);
     }
     SETUP_CLUSTER(n);
-    CLUSTER_BOOTSTRAP_N_VOTING(n_voting);
-    CLUSTER_START();
+    if (!v1) {
+        CLUSTER_BOOTSTRAP_N_VOTING(n_voting);
+        CLUSTER_START();
+    }
     return f;
 }
 
@@ -130,6 +132,20 @@ static MunitParameterEnum elapse_non_voter_params[] = {
     {"n_voting", elapse_non_voter_n_voting},
     {NULL, NULL},
 };
+
+/* If the election timeout has elapsed, but we're not part of the current
+ * configuration, stay follower. */
+TEST_V1(tick, timeoutWithServerNotInfConfiguration, setUp, tearDown, 0, NULL)
+{
+    struct fixture *f = data;
+    CLUSTER_START(1 /* ID */);
+    CLUSTER_TRACE(
+        "[   0] 1 > term 0, vote 0, no snapshot, no entries\n"
+        "[ 100] 1 > timeout as follower\n"
+        "           server not in current configuration -> stay follower\n");
+    munit_assert_int(raft_state(CLUSTER_RAFT(1)), ==, RAFT_FOLLOWER);
+    return MUNIT_OK;
+}
 
 /* If the election timeout has elapsed, but we're not voters, stay follower. */
 TEST(tick, not_voter, setUp, tearDown, 0, elapse_non_voter_params)

--- a/test/lib/cluster.c
+++ b/test/lib/cluster.c
@@ -307,8 +307,11 @@ static void serverStart(struct test_server *s)
     munit_assert_true(raft_state(r) == RAFT_FOLLOWER ||
                       raft_state(r) == RAFT_LEADER);
 
-    s->running = true;
+    /* The timeout must have changed. */
+    munit_assert_true(update.flags & RAFT_UPDATE_TIMEOUT);
     s->timeout = raft_timeout(&s->raft);
+
+    s->running = true;
 }
 
 void test_cluster_setup(const MunitParameter params[], struct test_cluster *c)

--- a/test/lib/cluster.h
+++ b/test/lib/cluster.h
@@ -614,6 +614,22 @@ struct test_server
     unsigned network_latency;     /* Network latency */
     unsigned disk_latency;        /* Disk latency */
     bool running;                 /* Whether the server is running */
+
+    /* The randomized_election_timeout field stores the value that the raft
+     * instance will obtain the next time it calls RandomWithinRange() to obtain
+     * a random number in the [election_timeout, election_timeout * 2] range. We
+     * do that by passing raft_seed() a value that makes the pseudor random
+     * number generator produce exactly randomized_election_timeout. That value
+     * is what we store in the seed field below. Since calculating the seed that
+     * matches the desired randomized_election_timeout is somehow expensive, we
+     * also use randomized_election_timeout_prev to store the previous value of
+     * randomized_election_timeout, in order to re-use the same seed if nothing
+     * has changed.
+     *
+     * See serverSeed for more details. */
+    unsigned randomized_election_timeout;
+    unsigned randomized_election_timeout_prev;
+    unsigned seed;
 };
 
 /* Cluster of test raft servers instances with fake disk and network I/O. */

--- a/test/lib/cluster.h
+++ b/test/lib/cluster.h
@@ -608,6 +608,7 @@ struct test_server
 {
     struct test_disk disk;        /* Persisted data */
     struct raft_tracer tracer;    /* Custom tracer */
+    struct raft_update update;    /* Passed to raft_step() */
     struct raft raft;             /* Raft instance */
     struct test_cluster *cluster; /* Parent cluster */
     raft_time timeout;            /* Next scheduled timeout */
@@ -664,6 +665,10 @@ void test_cluster_add_entry(struct test_cluster *c,
 /* Start the server with the given @id, using the current state persisted on its
  * disk. */
 void test_cluster_start(struct test_cluster *c, raft_id id);
+
+/* Advance the cluster by completing a single asynchronous operation or firing a
+ * timeout. */
+void test_cluster_step(struct test_cluster *c);
 
 /* Compare the trace of all messages emitted by all servers with the given
  * expected trace. If they don't match, print the last line which differs and


### PR DESCRIPTION
The new `test_cluster_step()` function is used to drive the cluster servers using the `raft_step()` API.