### PR TITLE
test: Convert some test cases to the v1 API

### DIFF
--- a/src/client.c
+++ b/src/client.c
@@ -11,6 +11,7 @@
 #include "request.h"
 #include "tracing.h"
 
+#define infof(...) Infof(r->tracer, "  " __VA_ARGS__)
 #define tracef(...) Tracef(r->tracer, __VA_ARGS__)
 
 /* This function is called when a new configuration entry is being submitted. It
@@ -71,6 +72,9 @@ int ClientSubmit(struct raft *r, struct raft_entry *entries, unsigned n)
     /* Index of the first entry being appended. */
     index = logLastIndex(r->log) + 1;
 
+    infof("persist %u entries with first index %lld at term %lld", n, index,
+          entries[0].term);
+
     for (i = 0; i < n; i++) {
         struct raft_entry *entry = &entries[i];
 
@@ -120,7 +124,6 @@ int raft_apply(struct raft *r,
 
     /* Index of the first entry being appended. */
     index = logLastIndex(r->log) + 1;
-    tracef("%u commands starting at %lld", n, index);
     req->type = RAFT_COMMAND;
     req->index = index;
     req->cb = cb;
@@ -585,4 +588,5 @@ err:
     return rv;
 }
 
+#undef infof
 #undef tracef

--- a/src/election.c
+++ b/src/election.c
@@ -8,6 +8,7 @@
 #include "random.h"
 #include "tracing.h"
 
+#define infof(...) Infof(r->tracer, "  " __VA_ARGS__)
 #define tracef(...) Tracef(r->tracer, __VA_ARGS__)
 
 /* Common fields between follower and candidate state.
@@ -255,7 +256,10 @@ int electionVote(struct raft *r,
 
     if (local_last_index <= args->last_log_index) {
         /* Our log is shorter or equal to the one of the requester. */
-        tracef("remote log equal or longer than local -> granting vote");
+        infof(
+            "remote log equal or longer (%llu.%llu vs %llu.%llu) -> grant vote",
+            args->last_log_index, args->last_log_term, local_last_index,
+            local_last_term);
         goto grant_vote;
     }
 
@@ -302,4 +306,5 @@ bool electionTally(struct raft *r, size_t voter_index)
     return votes >= half + 1;
 }
 
+#undef infof
 #undef tracef

--- a/src/progress.c
+++ b/src/progress.c
@@ -214,6 +214,28 @@ int progressState(struct raft *r, const unsigned i)
     return p->state;
 }
 
+const char *progressStateName(struct raft *r, unsigned i)
+{
+    struct raft_progress *p = &r->leader_state.progress[i];
+    const char *name;
+    switch (p->state) {
+        case PROGRESS__PROBE:
+            name = "probe";
+            break;
+        case PROGRESS__PIPELINE:
+            name = "pipeline";
+            break;
+        case PROGRESS__SNAPSHOT:
+            name = "snapshot";
+            break;
+        default:
+            assert(0);
+            name = NULL;
+            break;
+    }
+    return name;
+}
+
 bool progressMaybeDecrement(struct raft *r,
                             const unsigned i,
                             raft_index rejected,

--- a/src/progress.h
+++ b/src/progress.h
@@ -103,6 +103,9 @@ void progressAbortSnapshot(struct raft *r, unsigned i);
 /* Return the progress mode code for the i'th server. */
 int progressState(struct raft *r, unsigned i);
 
+/* Return the progress mode name for the i'th server. */
+const char *progressStateName(struct raft *r, unsigned i);
+
 /* Optimistically update the next index of the given server.
  *
  * Called in pipeline mode after sending new entries. */

--- a/src/raft.c
+++ b/src/raft.c
@@ -322,6 +322,34 @@ static int stepReceive(struct raft *r,
                        const char *address,
                        struct raft_message *message)
 {
+    const char *desc;
+
+    switch (message->type) {
+        case RAFT_IO_REQUEST_VOTE:
+            desc = "request vote";
+            break;
+        case RAFT_IO_REQUEST_VOTE_RESULT:
+            desc = "request vote result";
+            break;
+        case RAFT_IO_APPEND_ENTRIES:
+            desc = "append entries";
+            break;
+        case RAFT_IO_APPEND_ENTRIES_RESULT:
+            desc = "append entries result";
+            break;
+        case RAFT_IO_INSTALL_SNAPSHOT:
+            desc = "install snapshot";
+            break;
+        case RAFT_IO_TIMEOUT_NOW:
+            desc = "timeout now";
+            break;
+        default:
+            desc = "unknown message";
+            break;
+    }
+
+    infof("recv %s from server %llu", desc, id);
+
     return recvMessage(r, id, address, message);
 }
 

--- a/src/recv.c
+++ b/src/recv.c
@@ -17,6 +17,7 @@
 #include "string.h"
 #include "tracing.h"
 
+#define infof(...) Infof(r->tracer, "  " __VA_ARGS__)
 #define tracef(...) Tracef(r->tracer, __VA_ARGS__)
 
 /* Dispatch a single RPC message to the appropriate handler. */
@@ -126,12 +127,12 @@ int recvBumpCurrentTerm(struct raft *r, raft_term term)
     assert(r != NULL);
     assert(term > r->current_term);
 
-    sprintf(msg, "remote term %lld is higher than %lld -> bump local term",
-            term, r->current_term);
+    sprintf(msg, "remote term is higher (%lld vs %lld) -> bump term", term,
+            r->current_term);
     if (r->state != RAFT_FOLLOWER) {
         strcat(msg, " and step down");
     }
-    tracef("%s", msg);
+    infof("%s", msg);
 
     /* Mark both the current term and vote as changed. */
     r->update->flags |= RAFT_UPDATE_CURRENT_TERM | RAFT_UPDATE_VOTED_FOR;
@@ -225,4 +226,5 @@ int recvUpdateLeader(struct raft *r, const raft_id id, const char *address)
     return 0;
 }
 
+#undef infof
 #undef tracef

--- a/src/recv_request_vote_result.c
+++ b/src/recv_request_vote_result.c
@@ -8,6 +8,7 @@
 #include "replication.h"
 #include "tracing.h"
 
+#define infof(...) Infof(r->tracer, "  " __VA_ARGS__)
 #define tracef(...) Tracef(r->tracer, __VA_ARGS__)
 
 int recvRequestVoteResult(struct raft *r,
@@ -126,7 +127,7 @@ int recvRequestVoteResult(struct raft *r,
                 r->candidate_state.in_pre_vote = false;
                 electionStart(r);
             } else {
-                tracef("votes quorum reached -> convert to leader");
+                infof("votes quorum reached -> convert to leader");
                 rv = convertToLeader(r);
                 if (rv != 0) {
                     return rv;
@@ -144,4 +145,5 @@ int recvRequestVoteResult(struct raft *r,
     return 0;
 }
 
+#undef infof
 #undef tracef

--- a/src/replication.c
+++ b/src/replication.c
@@ -377,7 +377,9 @@ static int leaderPersistEntriesDone(struct raft *r,
      * giving the cluster a chance to elect another leader that doesn't have a
      * full disk (or whatever caused our write error). */
     if (status != 0) {
-        ErrMsgTransfer(r->io->errmsg, r->errmsg, "io");
+        if (r->io != NULL) {
+            ErrMsgTransfer(r->io->errmsg, r->errmsg, "io");
+        }
         convertToFollower(r);
         goto out;
     }

--- a/src/replication.c
+++ b/src/replication.c
@@ -21,6 +21,7 @@
 #include "restore.h"
 #include "tracing.h"
 
+#define infof(...) Infof(r->tracer, "  " __VA_ARGS__)
 #define tracef(...) Tracef(r->tracer, __VA_ARGS__)
 
 #ifndef max
@@ -108,9 +109,9 @@ static int sendAppendEntries(struct raft *r,
      */
     args->leader_commit = r->commit_index;
 
-    tracef("send %u entries starting at %llu to server %llu (last index %llu)",
-           args->n_entries, args->prev_log_index, server->id,
-           logLastIndex(r->log));
+    infof("%s server %llu sending %u entries with first index %llu",
+          progressStateName(r, i), server->id, args->n_entries,
+          args->prev_log_index + 1);
 
     message.type = RAFT_IO_APPEND_ENTRIES;
     message.server_id = server->id;
@@ -1220,4 +1221,5 @@ inline bool replicationInstallSnapshotBusy(struct raft *r)
     return r->last_stored == 0 && r->snapshot.persisting;
 }
 
+#undef infof
 #undef tracef

--- a/src/tick.c
+++ b/src/tick.c
@@ -54,7 +54,8 @@ static int tickFollower(struct raft *r)
             electionResetTimer(r);
             goto out;
         }
-        tracef("convert to candidate and start new election");
+        infof("convert to candidate and start new election for term %llu",
+              r->current_term + 1);
         rv = convertToCandidate(r, false /* disrupt leader */);
         if (rv != 0) {
             tracef("convert to candidate: %s", raft_strerror(rv));

--- a/test/integration/test_start.c
+++ b/test/integration/test_start.c
@@ -64,7 +64,7 @@ TEST_V1(raft_start, noState, setUp, tearDown, 0, NULL)
 {
     struct fixture *f = data;
     CLUSTER_START(1);
-    CLUSTER_TRACE("[   0] 1 > term 0, vote 0, no snapshot, no entries\n");
+    CLUSTER_TRACE("   0 U 1 > term 0, vote 0, no snapshot, no entries\n");
     munit_assert_int(raft_timeout(CLUSTER_RAFT(1)), ==, 100);
     return MUNIT_OK;
 }
@@ -75,7 +75,7 @@ TEST_V1(raft_start, persistedTerm, setUp, tearDown, 0, NULL)
     struct fixture *f = data;
     CLUSTER_SET_TERM(1 /* ID */, 1 /* term */);
     CLUSTER_START(1 /* ID */);
-    CLUSTER_TRACE("[   0] 1 > term 1, vote 0, no snapshot, no entries\n");
+    CLUSTER_TRACE("   0 U 1 > term 1, vote 0, no snapshot, no entries\n");
     return MUNIT_OK;
 }
 
@@ -91,7 +91,7 @@ TEST_V1(raft_start, persistedTermAndSnapshot, setUp, tearDown, 0, NULL)
                          2, /* N voting                                  */
                          1 /* conf index                                */);
     CLUSTER_START(1 /* ID */);
-    CLUSTER_TRACE("[   0] 1 > term 2, vote 0, snapshot 6.2, no entries\n");
+    CLUSTER_TRACE("   0 U 1 > term 2, vote 0, snapshot 6.2, no entries\n");
     return MUNIT_OK;
 }
 
@@ -104,7 +104,7 @@ TEST_V1(raft_start, persistedTermAndEntries, setUp, tearDown, 0, NULL)
     CLUSTER_ADD_ENTRY(1 /* ID */, RAFT_CHANGE, 2 /* servers */, 2 /* voters */);
     CLUSTER_START(1 /* ID */);
     CLUSTER_TRACE(
-        "[   0] 1 > term 1, vote 0, no snapshot, entries 1.1 to 1.1\n");
+        "   0 U 1 > term 1, vote 0, no snapshot, entries 1.1 to 1.1\n");
     return MUNIT_OK;
 }
 

--- a/test/integration/test_tick.c
+++ b/test/integration/test_tick.c
@@ -140,8 +140,8 @@ TEST_V1(tick, timeoutWithServerNotInfConfiguration, setUp, tearDown, 0, NULL)
     struct fixture *f = data;
     CLUSTER_START(1 /* ID */);
     CLUSTER_TRACE(
-        "[   0] 1 > term 0, vote 0, no snapshot, no entries\n"
-        "[ 100] 1 > timeout as follower\n"
+        "   0 U 1 > term 0, vote 0, no snapshot, no entries\n"
+        " 100 F 1 > timeout as follower\n"
         "           server not in current configuration -> stay follower\n");
     munit_assert_int(raft_state(CLUSTER_RAFT(1)), ==, RAFT_FOLLOWER);
     return MUNIT_OK;

--- a/test/lib/cluster.h
+++ b/test/lib/cluster.h
@@ -608,7 +608,6 @@ struct test_server
 {
     struct test_disk disk;        /* Persisted data */
     struct raft_tracer tracer;    /* Custom tracer */
-    struct raft_update update;    /* Passed to raft_step() */
     struct raft raft;             /* Raft instance */
     struct test_cluster *cluster; /* Parent cluster */
     raft_time timeout;            /* Next scheduled timeout */


### PR DESCRIPTION
Improve the v1-based test cluster machinery and convert a few existing tests to use that instead of the legacy `struct raft_fixture` from v0.