### PR TITLE
test: Convert replicaton tests to the v1 API

### DIFF
--- a/src/client.c
+++ b/src/client.c
@@ -67,7 +67,6 @@ int ClientSubmit(struct raft *r, struct raft_entry *entries, unsigned n)
     if (r->state != RAFT_LEADER || r->transfer != NULL) {
         rv = RAFT_NOTLEADER;
         ErrMsgFromCode(r->errmsg, rv);
-        tracef("raft_apply not leader");
         goto err;
     }
 
@@ -125,8 +124,6 @@ int raft_apply(struct raft *r,
     struct raft_event event;
     struct raft_entry entry;
     int rv;
-
-    tracef("raft_apply n %d", n);
 
     assert(r != NULL);
     assert(bufs != NULL);
@@ -248,8 +245,6 @@ int raft_add(struct raft *r,
         return rv;
     }
 
-    tracef("add server: id %llu, address %s", id, address);
-
     /* Make a copy of the current configuration, and add the new server to
      * it. */
     rv = configurationCopy(&r->configuration, &configuration);
@@ -330,7 +325,6 @@ int raft_assign(struct raft *r,
 
     r->now = r->io->time(r->io);
 
-    tracef("raft_assign to id:%llu the role:%d", id, role);
     if (role != RAFT_STANDBY && role != RAFT_VOTER && role != RAFT_SPARE) {
         rv = RAFT_BADROLE;
         ErrMsgFromCode(r->errmsg, rv);
@@ -393,7 +387,6 @@ int raft_assign(struct raft *r,
 
         rv = clientChangeConfiguration(r, &r->configuration);
         if (rv != 0) {
-            tracef("clientChangeConfiguration failed %d", rv);
             r->configuration.servers[server_index].role = old_role;
             return rv;
         }
@@ -438,8 +431,6 @@ int raft_remove(struct raft *r,
         rv = RAFT_BADID;
         goto err;
     }
-
-    tracef("remove server: id %llu", id);
 
     /* Make a copy of the current configuration, and remove the given server
      * from it. */
@@ -552,9 +543,7 @@ int raft_transfer(struct raft *r,
     unsigned i;
     int rv;
 
-    tracef("transfer to %llu", id);
     if (r->state != RAFT_LEADER || r->transfer != NULL) {
-        tracef("transfer error - state:%d", r->state);
         rv = RAFT_NOTLEADER;
         ErrMsgFromCode(r->errmsg, rv);
         goto err;

--- a/src/client.c
+++ b/src/client.c
@@ -196,8 +196,9 @@ err:
     return rv;
 }
 
-int ClientChangeConfiguration(struct raft *r,
-                              const struct raft_configuration *configuration)
+static int clientChangeConfiguration(
+    struct raft *r,
+    const struct raft_configuration *configuration)
 {
     struct raft_entry entry;
     struct raft_event event;
@@ -258,7 +259,7 @@ int raft_add(struct raft *r,
     req->cb = cb;
     req->catch_up_id = 0;
 
-    rv = ClientChangeConfiguration(r, &configuration);
+    rv = clientChangeConfiguration(r, &configuration);
     if (rv != 0) {
         goto err_after_configuration_copy;
     }
@@ -384,9 +385,9 @@ int raft_assign(struct raft *r,
         int old_role = r->configuration.servers[server_index].role;
         r->configuration.servers[server_index].role = role;
 
-        rv = ClientChangeConfiguration(r, &r->configuration);
+        rv = clientChangeConfiguration(r, &r->configuration);
         if (rv != 0) {
-            tracef("ClientChangeConfiguration failed %d", rv);
+            tracef("clientChangeConfiguration failed %d", rv);
             r->configuration.servers[server_index].role = old_role;
             return rv;
         }
@@ -449,7 +450,7 @@ int raft_remove(struct raft *r,
     req->cb = cb;
     req->catch_up_id = 0;
 
-    rv = ClientChangeConfiguration(r, &configuration);
+    rv = clientChangeConfiguration(r, &configuration);
     if (rv != 0) {
         goto err_after_configuration_copy;
     }

--- a/src/client.h
+++ b/src/client.h
@@ -3,7 +3,20 @@
 
 #include "../include/raft.h"
 
-/* Submit the given entries and start replicating them. */
+/* Submit the given entries and start replicating them.
+ *
+ * Errors:
+ *
+ * RAFT_NOTLEADER
+ *     The server is not leader, or a leadership transfer is in progress.
+ *
+ * RAFT_MALFORMED
+ *     The submitted entry is of type RAFT_CHANGE, but the encoded configuration
+ *     is invalid.
+ *
+ * RAFT_NOMEM
+ *     Memory could not be allocated to store the new entry.
+ */
 int ClientSubmit(struct raft *r, struct raft_entry *entries, unsigned n);
 
 /* Start catching-up the given server. */

--- a/src/client.h
+++ b/src/client.h
@@ -12,8 +12,4 @@ void ClientCatchUp(struct raft *r, raft_id server_id);
 /* Start transferring leadership to the given server. */
 int ClientTransfer(struct raft *r, raft_id server_id);
 
-/* Submit a new RAFT_CHANGE entry with the given new configuration. */
-int ClientChangeConfiguration(struct raft *r,
-                              const struct raft_configuration *configuration);
-
 #endif /* CLIENT_H_ */

--- a/src/convert.c
+++ b/src/convert.c
@@ -12,8 +12,7 @@
 #include "request.h"
 #include "tracing.h"
 
-#define infof(...) Tracef(r->tracer, __VA_ARGS__)
-#define tracef(...) Tracef(r->tracer, __VA_ARGS__)
+#define infof(...) Infof(r->tracer, "  " __VA_ARGS__)
 
 /* Convenience for setting a new state value and asserting that the transition
  * is valid. */
@@ -216,4 +215,3 @@ void convertToUnavailable(struct raft *r)
 }
 
 #undef infof
-#undef tracef

--- a/src/convert.h
+++ b/src/convert.h
@@ -23,7 +23,13 @@ void convertToFollower(struct raft *r);
  *   On conversion to candidate, start election
  *
  * If the disrupt_leader flag is true, the server will set the disrupt leader
- * flag of the RequestVote messages it sends.  */
+ * flag of the RequestVote messages it sends.
+ *
+ * Errors:
+ *
+ * RAFT_NOMEM
+ *     Memory for the votes array could not be allocated.
+ */
 int convertToCandidate(struct raft *r, bool disrupt_leader);
 
 /* Convert from candidate to leader.

--- a/src/convert.h
+++ b/src/convert.h
@@ -50,7 +50,13 @@ int convertToCandidate(struct raft *r, bool disrupt_leader);
  *   The leader maintains a nextIndex for each follower, which is the index
  *   of the next log entry the leader will send to that follower. When a
  *   leader first comes to power, it initializes all nextIndex values to the
- *   index just after the last one in its log. */
+ *   index just after the last one in its log.
+ * Errors:
+ *
+ * RAFT_NOMEM
+ *     Memory for the progress array or for the initial no-op entry could
+ *     not be allocated.
+ */
 int convertToLeader(struct raft *r);
 
 void convertToUnavailable(struct raft *r);

--- a/src/election.c
+++ b/src/election.c
@@ -294,7 +294,7 @@ grant_vote:
 }
 
 bool electionTally(struct raft *r,
-                   size_t voter_index,
+                   const size_t voter_index,
                    unsigned *votes,
                    unsigned *n_voters)
 {

--- a/src/election.c
+++ b/src/election.c
@@ -108,6 +108,7 @@ static int electionSend(struct raft *r, const struct raft_server *server)
 
     rv = MessageEnqueue(r, &message);
     if (rv != 0) {
+        assert(rv == RAFT_NOMEM);
         return rv;
     }
 
@@ -172,8 +173,9 @@ void electionStart(struct raft *r)
         rv = electionSend(r, server);
         if (rv != 0) {
             /* This is not a critical failure, let's just log it. */
-            tracef("failed to send vote request to server %llu: %s", server->id,
-                   raft_strerror(rv));
+            assert(rv == RAFT_NOMEM);
+            infof("can't send vote request to server %llu: %s", server->id,
+                  raft_strerror(rv));
         }
     }
 }

--- a/src/election.c
+++ b/src/election.c
@@ -180,9 +180,9 @@ void electionStart(struct raft *r)
     }
 }
 
-int electionVote(struct raft *r,
-                 const struct raft_request_vote *args,
-                 bool *granted)
+void electionVote(struct raft *r,
+                  const struct raft_request_vote *args,
+                  bool *granted)
 {
     const struct raft_server *local_server;
     raft_index local_last_index;
@@ -199,7 +199,7 @@ int electionVote(struct raft *r,
 
     if (local_server == NULL || local_server->role != RAFT_VOTER) {
         infof("local server is not voting -> don't grant vote");
-        return 0;
+        return;
     }
 
     is_transferee =
@@ -208,7 +208,7 @@ int electionVote(struct raft *r,
         r->voted_for != args->candidate_id && !is_transferee) {
         infof("already voted for server %llu -> don't grant vote",
               r->voted_for);
-        return 0;
+        return;
     }
 
     /* Raft Dissertation 9.6:
@@ -240,7 +240,7 @@ int electionVote(struct raft *r,
         infof("remote log older (%llu^%llu vs %llu^%llu) -> don't grant vote",
               args->last_log_index, args->last_log_term, local_last_index,
               local_last_term);
-        return 0;
+        return;
     }
 
     if (args->last_log_term > local_last_term) {
@@ -269,7 +269,7 @@ int electionVote(struct raft *r,
           args->last_log_index, args->last_log_term, local_last_index,
           local_last_term);
 
-    return 0;
+    return;
 
 grant_vote:
     if (!args->pre_vote) {
@@ -284,8 +284,6 @@ grant_vote:
     }
 
     *granted = true;
-
-    return 0;
 }
 
 bool electionTally(struct raft *r,

--- a/src/election.c
+++ b/src/election.c
@@ -208,20 +208,19 @@ void electionVote(struct raft *r,
         return;
     }
 
-    /* Raft Dissertation 9.6:
-     * > In the Pre-Vote algorithm, a candidate
-     * > only increments its term if it first learns from a majority of the
-     * > cluster that they would be willing
-     * > to grant the candidate their votes (if the candidate's log is
-     * > sufficiently up-to-date, and the voters
-     * > have not received heartbeats from a valid leader for at least a
-     * baseline > election timeout) Arriving here means that in a pre-vote
-     * phase, we will cast our vote if the candidate's log is sufficiently
-     * up-to-date, no matter what the candidate's term is. We have already
-     * checked if we currently have a leader upon reception of the RequestVote
-     * RPC, meaning the 2 conditions will be satisfied if the candidate's log is
-     * up-to-date.
-     * */
+    /* From Section 9.6:
+     *
+     *   In the Pre-Vote algorithm, a candidate only increments its term if it
+     *   first learns from a majority of the cluster that they would be willing
+     *   to grant the candidate their votes (if the candidate's log is
+     *   sufficiently up-to-date, and the voters have not received heartbeats
+     *   from a valid leader for at least a baseline election timeout).
+     *
+     * Arriving here means that in a pre-vote phase, we will cast our vote if
+     * the candidate's log is sufficiently up-to-date, no matter what the
+     * candidate's term is. We have already checked if we currently have a
+     * leader upon reception of the RequestVote RPC, meaning the 2 conditions
+     * will be satisfied if the candidate's log is up-to-date. */
     local_last_index = logLastIndex(r->log);
 
     /* Our log is definitely not more up-to-date if it's empty! */

--- a/src/election.c
+++ b/src/election.c
@@ -187,7 +187,6 @@ void electionVote(struct raft *r,
     const struct raft_server *local_server;
     raft_index local_last_index;
     raft_term local_last_term;
-    bool is_transferee; /* Requester is the target of a leadership transfer */
 
     assert(r != NULL);
     assert(args != NULL);
@@ -202,10 +201,8 @@ void electionVote(struct raft *r,
         return;
     }
 
-    is_transferee =
-        r->transfer != NULL && r->transfer->id == args->candidate_id;
     if (!args->pre_vote && r->voted_for != 0 &&
-        r->voted_for != args->candidate_id && !is_transferee) {
+        r->voted_for != args->candidate_id) {
         infof("already voted for server %llu -> don't grant vote",
               r->voted_for);
         return;

--- a/src/election.c
+++ b/src/election.c
@@ -84,7 +84,7 @@ static int electionSend(struct raft *r, const struct raft_server *server)
     /* Fill the RequestVote message.
      *
      * Note that we set last_log_index and last_log_term to the index and term
-     * of the last persisted entry, to the last entry in our in-memory log
+     * of the last persisted entry, not to the last entry in our in-memory log
      * cache, because we must advertise only log entries that can't be lost at
      * restart.
      *

--- a/src/election.c
+++ b/src/election.c
@@ -116,7 +116,6 @@ static int electionSend(struct raft *r, const struct raft_server *server)
 
 void electionStart(struct raft *r)
 {
-    raft_term term;
     size_t n_voters;
     size_t voting_index;
     size_t i;
@@ -138,18 +137,15 @@ void electionStart(struct raft *r)
 
     /* During pre-vote we don't increment our term, or reset our vote. Resetting
      * our vote could lead to double-voting if we were to receive a RequestVote
-     * RPC during our Candidate state while we already voted for a server during
-     * the term. */
+     * RPC during our Candidate state, while we actually already voted for a
+     * server during the term. */
     if (!r->candidate_state.in_pre_vote) {
         /* Increment current term and vote for self */
-        term = r->current_term + 1;
+        r->current_term += 1;
+        r->voted_for = r->id;
 
         /* Mark both the current term and vote as changed. */
         r->update->flags |= RAFT_UPDATE_CURRENT_TERM | RAFT_UPDATE_VOTED_FOR;
-
-        /* Update our cache too. */
-        r->current_term = term;
-        r->voted_for = r->id;
     }
 
     /* Reset election timer. */

--- a/src/election.c
+++ b/src/election.c
@@ -9,7 +9,6 @@
 #include "tracing.h"
 
 #define infof(...) Infof(r->tracer, "  " __VA_ARGS__)
-#define tracef(...) Tracef(r->tracer, __VA_ARGS__)
 
 /* Common fields between follower and candidate state.
  *
@@ -321,4 +320,3 @@ bool electionTally(struct raft *r,
 }
 
 #undef infof
-#undef tracef

--- a/src/election.h
+++ b/src/election.h
@@ -79,9 +79,9 @@ void electionStart(struct raft *r);
  *     up-to-date as receiver's log, grant vote.
  *
  * The outcome of the decision is stored through the @granted pointer. */
-int electionVote(struct raft *r,
-                 const struct raft_request_vote *args,
-                 bool *granted);
+void electionVote(struct raft *r,
+                  const struct raft_request_vote *args,
+                  bool *granted);
 
 /* Update the votes array by adding the vote from the server at the given
  * index. Return true if with this vote the server has reached the majority of

--- a/src/log.h
+++ b/src/log.h
@@ -94,7 +94,17 @@ raft_term logSnapshotTerm(struct raft_log *l);
  * invoked. Return #NULL if there is no such entry. */
 const struct raft_entry *logGet(struct raft_log *l, const raft_index index);
 
-/* Append a new entry to the log. */
+/* Append a new entry to the log.
+ *
+ * Errors:
+ *
+ * RAFT_BUSY
+ *     Attempt to append an index with the same index and term of a referenced
+ *     one (e.g. the referenced entry is being persisted).
+ *
+ * RAFT_NOMEM
+ *     Memory for the new entry could not be allocated.
+ */
 int logAppend(struct raft_log *l,
               raft_term term,
               unsigned short type,

--- a/src/message.h
+++ b/src/message.h
@@ -5,7 +5,7 @@
 
 #include "../include/raft.h"
 
-/* Add the given message to the array of messages attached to next struct
+/* Add the given message to the array of messages attached to the struct
  * raft_update to be returned.
  *
  * Errors:

--- a/src/progress.h
+++ b/src/progress.h
@@ -33,7 +33,13 @@ struct raft_progress
 
 /* Create and initialize the array of progress objects used by the leader to
  * track followers. The match index will be set to zero, and the next index to
- * the current last index plus 1. */
+ * the current last index plus 1.
+ *
+ * Errors:
+ *
+ * RAFT_NOMEM
+ *     Memory for the progress array could not be allocated.
+ */
 int progressBuildArray(struct raft *r);
 
 /* Re-build the progress array against a new configuration.

--- a/src/progress.h
+++ b/src/progress.h
@@ -48,7 +48,11 @@ int progressBuildArray(struct raft *r);
  * configuration will remain unchanged.
  *
  * Progress information for servers existing only in the new configuration will
- * be initialized as in progressBuildArray().*/
+ * be initialized as in progressBuildArray().
+ *
+ * RAFT_NOMEM
+ *     Memory for the progress array could not be allocated.
+ */
 int progressRebuildArray(struct raft *r,
                          const struct raft_configuration *configuration);
 

--- a/src/recv.c
+++ b/src/recv.c
@@ -18,7 +18,6 @@
 #include "tracing.h"
 
 #define infof(...) Infof(r->tracer, "  " __VA_ARGS__)
-#define tracef(...) Tracef(r->tracer, __VA_ARGS__)
 
 /* Dispatch a single RPC message to the appropriate handler. */
 int recvMessage(struct raft *r,
@@ -61,13 +60,11 @@ int recvMessage(struct raft *r,
             rv = recvTimeoutNow(r, id, address, &message->timeout_now);
             break;
         default:
-            tracef("received unknown message type (%d)", message->type);
             /* Drop message */
             return 0;
     };
 
     if (rv != 0 && rv != RAFT_NOCONNECTION) {
-        tracef("recv: %d: %s", message->type, raft_strerror(rv));
         return rv;
     }
 
@@ -170,8 +167,6 @@ int recvEnsureMatchingTerms(struct raft *r, raft_term term, int *match)
     recvCheckMatchingTerms(r, term, match);
 
     if (*match == -1) {
-        tracef("old term - current_term:%llu other_term:%llu", r->current_term,
-               term);
         return 0;
     }
 
@@ -192,7 +187,6 @@ int recvEnsureMatchingTerms(struct raft *r, raft_term term, int *match)
     if (*match == 1) {
         rv = recvBumpCurrentTerm(r, term);
         if (rv != 0) {
-            tracef("recvBumpCurrentTerm failed %d", rv);
             return rv;
         }
     }
@@ -227,4 +221,3 @@ int recvUpdateLeader(struct raft *r, const raft_id id, const char *address)
 }
 
 #undef infof
-#undef tracef

--- a/src/recv_append_entries.c
+++ b/src/recv_append_entries.c
@@ -12,7 +12,6 @@
 #include "tracing.h"
 
 #define infof(...) Infof(r->tracer, "  " __VA_ARGS__)
-#define tracef(...) Tracef(r->tracer, __VA_ARGS__)
 
 int recvAppendEntries(struct raft *r,
                       raft_id id,
@@ -46,7 +45,8 @@ int recvAppendEntries(struct raft *r,
      *   currentTerm.
      */
     if (match < 0) {
-        tracef("local term is higher -> reject ");
+        infof("local term is higher (%llu vs %llu) -> reject", r->current_term,
+              args->term);
         goto reply;
     }
 
@@ -107,7 +107,7 @@ int recvAppendEntries(struct raft *r,
      * something smarter, e.g. buffering the entries in the I/O backend, which
      * should be in charge of serializing everything. */
     if (replicationInstallSnapshotBusy(r) && args->n_entries > 0) {
-        tracef("ignoring AppendEntries RPC during snapshot install");
+        infof("ignoring AppendEntries RPC during snapshot install");
         entryBatchesDestroy(args->entries, args->n_entries);
         return 0;
     }
@@ -149,4 +149,3 @@ reply:
 }
 
 #undef infof
-#undef tracef

--- a/src/recv_append_entries_result.c
+++ b/src/recv_append_entries_result.c
@@ -5,7 +5,7 @@
 #include "replication.h"
 #include "tracing.h"
 
-#define tracef(...) Tracef(r->tracer, __VA_ARGS__)
+#define infof(...) Infof(r->tracer, "  " __VA_ARGS__)
 
 int recvAppendEntriesResult(struct raft *r,
                             const raft_id id,
@@ -21,12 +21,8 @@ int recvAppendEntriesResult(struct raft *r,
     assert(address != NULL);
     assert(result != NULL);
 
-    tracef("self:%llu from:%llu@%s last_log_index:%llu rejected:%llu term:%llu",
-           r->id, id, address, result->last_log_index, result->rejected,
-           result->term);
-
     if (r->state != RAFT_LEADER) {
-        tracef("local server is not leader -> ignore");
+        infof("local server is not leader -> ignore");
         return 0;
     }
 
@@ -36,7 +32,8 @@ int recvAppendEntriesResult(struct raft *r,
     }
 
     if (match < 0) {
-        tracef("local term is higher -> ignore ");
+        infof("local term is higher (%llu vs %llu) -> ignore", r->current_term,
+              result->term);
         return 0;
     }
 
@@ -57,7 +54,7 @@ int recvAppendEntriesResult(struct raft *r,
     /* Ignore responses from servers that have been removed */
     server = configurationGet(&r->configuration, id);
     if (server == NULL) {
-        tracef("unknown server -> ignore");
+        infof("unknown server -> ignore");
         return 0;
     }
 
@@ -70,4 +67,4 @@ int recvAppendEntriesResult(struct raft *r,
     return 0;
 }
 
-#undef tracef
+#undef infof

--- a/src/recv_request_vote.c
+++ b/src/recv_request_vote.c
@@ -105,10 +105,7 @@ int recvRequestVote(struct raft *r,
         assert(r->current_term == args->term);
     }
 
-    rv = electionVote(r, args, &result->vote_granted);
-    if (rv != 0) {
-        return rv;
-    }
+    electionVote(r, args, &result->vote_granted);
 
 reply:
     result->term = r->current_term;

--- a/src/recv_request_vote_result.c
+++ b/src/recv_request_vote_result.c
@@ -9,7 +9,6 @@
 #include "tracing.h"
 
 #define infof(...) Infof(r->tracer, "  " __VA_ARGS__)
-#define tracef(...) Tracef(r->tracer, __VA_ARGS__)
 
 int recvRequestVoteResult(struct raft *r,
                           raft_id id,
@@ -27,7 +26,7 @@ int recvRequestVoteResult(struct raft *r,
 
     votes_index = configurationIndexOfVoter(&r->configuration, id);
     if (votes_index == r->configuration.n) {
-        tracef("non-voting or unknown server -> reject");
+        infof("non-voting or unknown server -> reject");
         return 0;
     }
 
@@ -53,7 +52,7 @@ int recvRequestVoteResult(struct raft *r,
 
     /* Converted to follower as a result of seeing a higher term. */
     if (r->state != RAFT_CANDIDATE) {
-        tracef("no longer candidate -> ignore");
+        infof("no longer candidate -> ignore");
         return 0;
     }
 
@@ -79,7 +78,7 @@ int recvRequestVoteResult(struct raft *r,
      * out before crashing. */
     if (result->version > 1 && !result->pre_vote &&
         r->candidate_state.in_pre_vote) {
-        tracef("receive vote response during pre-vote -> ignore");
+        infof("receive vote response during pre-vote -> ignore");
         return 0;
     }
 
@@ -149,4 +148,3 @@ int recvRequestVoteResult(struct raft *r,
 }
 
 #undef infof
-#undef tracef

--- a/src/recv_timeout_now.c
+++ b/src/recv_timeout_now.c
@@ -7,7 +7,7 @@
 #include "recv.h"
 #include "tracing.h"
 
-#define tracef(...) Tracef(r->tracer, __VA_ARGS__)
+#define infof(...) Infof(r->tracer, "  " __VA_ARGS__)
 
 int recvTimeoutNow(struct raft *r,
                    const raft_id id,
@@ -26,15 +26,10 @@ int recvTimeoutNow(struct raft *r,
 
     (void)address;
 
-    tracef(
-        "self:%llu from:%llu@%s last_log_index:%llu last_log_term:%llu "
-        "term:%llu",
-        r->id, id, address, args->last_log_index, args->last_log_term,
-        args->term);
     /* Ignore the request if we are not voters. */
     local_server = configurationGet(&r->configuration, r->id);
     if (local_server == NULL || local_server->role != RAFT_VOTER) {
-        tracef("non-voter");
+        infof("non-voter");
         return 0;
     }
 
@@ -42,8 +37,8 @@ int recvTimeoutNow(struct raft *r,
      * leader. */
     if (r->state != RAFT_FOLLOWER ||
         r->follower_state.current_leader.id != id) {
-        tracef("Ignore - r->state:%d current_leader.id:%llu", r->state,
-               r->follower_state.current_leader.id);
+        infof("ignore - r->state:%d current_leader.id:%llu", r->state,
+              r->follower_state.current_leader.id);
         return 0;
     }
 
@@ -74,4 +69,4 @@ int recvTimeoutNow(struct raft *r,
     return 0;
 }
 
-#undef tracef
+#undef infof

--- a/src/replication.c
+++ b/src/replication.c
@@ -269,7 +269,7 @@ int replicationProgress(struct raft *r, unsigned i)
          * we're not doing so already. */
         if (prev_term == 0 && !progress_state_is_snapshot) {
             assert(prev_index < snapshot_index);
-            tracef("missing entry at index %lld -> send snapshot", prev_index);
+            infof("missing entry at index %lld -> send snapshot", prev_index);
             goto send_snapshot;
         }
     }
@@ -380,9 +380,6 @@ static int leaderPersistEntriesDone(struct raft *r,
     size_t server_index;
 
     assert(r->state == RAFT_LEADER);
-
-    tracef("leader: written %u entries starting at %lld: status %d", n, index,
-           status);
 
     /* In case of a failed disk write, convert immediately to follower state,
      * giving the cluster a chance to elect another leader that doesn't have a
@@ -503,7 +500,6 @@ static int appendLeader(struct raft *r, raft_index index)
      * some entries to write. */
     if (n == 0) {
         assert(false);
-        tracef("No log entries found at index %llu", index);
         ErrMsgPrintf(r->errmsg, "No log entries found at index %llu", index);
         rv = RAFT_SHUTDOWN;
         goto err_after_entries_acquired;
@@ -701,8 +697,6 @@ static int followerPersistEntriesDone(struct raft *r,
 
     assert(r->state == RAFT_FOLLOWER);
 
-    tracef("I/O completed on follower: status %d", status);
-
     assert(entries != NULL);
     assert(n > 0);
 
@@ -789,7 +783,7 @@ static int checkLogMatchingProperty(struct raft *r,
     if (local_prev_term != args->prev_log_term) {
         if (args->prev_log_index <= r->commit_index) {
             /* Should never happen; something is seriously wrong! */
-            tracef(
+            infof(
                 "conflicting terms %llu and %llu for entry %llu (commit "
                 "index %llu) -> shutdown",
                 local_prev_term, args->prev_log_term, args->prev_log_index,
@@ -831,11 +825,11 @@ static int deleteConflictingEntries(struct raft *r,
         if (local_term > 0 && local_term != entry->term) {
             if (entry_index <= r->commit_index) {
                 /* Should never happen; something is seriously wrong! */
-                tracef("new index conflicts with committed entry -> shutdown");
                 return RAFT_SHUTDOWN;
             }
 
-            tracef("log mismatch -> truncate (%llu)", entry_index);
+            infof("log mismatch (%llu^%llu vs %llu^%llu) -> truncate",
+                  entry_index, local_term, entry_index, entry->term);
 
             /* Possibly discard uncommitted configuration changes. */
             if (r->configuration_uncommitted_index >= entry_index) {
@@ -1027,7 +1021,6 @@ int replicationPersistSnapshotDone(struct raft *r,
 
     /* If we are shutting down, let's discard the result. */
     if (r->state == RAFT_UNAVAILABLE) {
-        tracef("shutting down -> discard result of snapshot installation");
         goto discard;
     }
 
@@ -1049,7 +1042,7 @@ int replicationPersistSnapshotDone(struct raft *r,
         goto discard;
     }
 
-    tracef("restored snapshot with last index %llu", metadata->index);
+    infof("restored snapshot with last index %llu", metadata->index);
 
     goto respond;
 
@@ -1142,7 +1135,7 @@ int replicationApplyConfigurationChange(struct raft *r, raft_index index)
      * via an AppendEntries RPC (for followers), then reset the uncommitted
      * index, since that uncommitted configuration is now committed. */
     if (r->configuration_uncommitted_index == index) {
-        tracef("configuration at index:%llu is committed.", index);
+        infof("configuration at index:%llu is committed.", index);
         r->configuration_uncommitted_index = 0;
     }
 
@@ -1161,8 +1154,8 @@ int replicationApplyConfigurationChange(struct raft *r, raft_index index)
          */
         server = configurationGet(&r->configuration, r->id);
         if (server == NULL || server->role != RAFT_VOTER) {
-            tracef("leader removed from config or no longer voter server: %p",
-                   (void *)server);
+            infof("leader removed from config or no longer voter server: %p",
+                  (void *)server);
             convertToFollower(r);
         }
     }

--- a/src/restore.c
+++ b/src/restore.c
@@ -85,6 +85,13 @@ int RestoreEntries(struct raft *r,
              * second to last configuration entry, if any. */
             if (conf_index != 0) {
                 r->configuration_committed_index = conf_index;
+                /* We also indirectly know that the commit index must be at
+                 * least as high as the index of this second to last
+                 * configuration entry. */
+                /* FIXME: this currently breaks incus/cowsql tests
+                r->commit_index = r->configuration_committed_index;
+                r->update->flags |= RAFT_UPDATE_COMMIT_INDEX;
+                */
             }
             conf = entry;
             conf_index = r->last_stored;

--- a/src/tick.c
+++ b/src/tick.c
@@ -11,7 +11,6 @@
 #include "tracing.h"
 
 #define infof(...) Infof(r->tracer, "  " __VA_ARGS__)
-#define tracef(...) Tracef(r->tracer, __VA_ARGS__)
 
 /* Apply time-dependent rules for followers (Figure 3.1). */
 static int tickFollower(struct raft *r)
@@ -50,7 +49,7 @@ static int tickFollower(struct raft *r)
             goto out;
         }
         if (replicationInstallSnapshotBusy(r)) {
-            tracef("installing snapshot -> don't convert to candidate");
+            infof("installing snapshot -> don't convert to candidate");
             electionResetTimer(r);
             goto out;
         }
@@ -58,7 +57,6 @@ static int tickFollower(struct raft *r)
               pre_vote_text, r->current_term + 1);
         rv = convertToCandidate(r, false /* disrupt leader */);
         if (rv != 0) {
-            tracef("convert to candidate: %s", raft_strerror(rv));
             return rv;
         }
     }
@@ -132,7 +130,7 @@ static int tickLeader(struct raft *r)
      */
     if (r->now - r->election_timer_start >= r->election_timeout) {
         if (!checkContactQuorum(r)) {
-            tracef("unable to contact majority of cluster -> step down");
+            infof("unable to contact majority of cluster -> step down");
             convertToFollower(r);
             return 0;
         }
@@ -183,8 +181,8 @@ static int tickLeader(struct raft *r)
         /* Abort the promotion if we are at the 10'th round and it's still
          * taking too long, or if the server is unresponsive. */
         if (is_too_slow || is_unresponsive) {
-            tracef("server_index:%d is_too_slow:%d is_unresponsive:%d",
-                   server_index, is_too_slow, is_unresponsive);
+            infof("server_index:%d is_too_slow:%d is_unresponsive:%d",
+                  server_index, is_too_slow, is_unresponsive);
 
             r->leader_state.promotee_id = 0;
 
@@ -257,4 +255,3 @@ err:
 }
 
 #undef infof
-#undef tracef

--- a/test/integration/test_election.c
+++ b/test/integration/test_election.c
@@ -130,7 +130,7 @@ TEST_V1(election, GrantAgain, setUp, tearDown, 0, NULL)
      * result and eventually starts a new election round. */
     CLUSTER_DISCONNECT(2, 1);
     CLUSTER_TRACE(
-        "[ 270] 1 > timeout as candidate\n"
+        "[ 200] 1 > timeout as candidate\n"
         "           stay candidate, start election for term 3\n");
 
     /* Reconnecting the two servers eventually makes the first server win the
@@ -138,12 +138,12 @@ TEST_V1(election, GrantAgain, setUp, tearDown, 0, NULL)
     CLUSTER_RECONNECT(2, 1);
 
     CLUSTER_TRACE(
-        "[ 280] 2 > recv request vote from server 1\n"
+        "[ 210] 2 > recv request vote from server 1\n"
         "           remote term is higher (3 vs 2) -> bump term\n"
         "           remote log equal or longer (1^1 vs 1^1) -> grant vote\n");
 
     CLUSTER_TRACE(
-        "[ 290] 1 > recv request vote result from server 2\n"
+        "[ 220] 1 > recv request vote result from server 2\n"
         "           quorum reached with 2 votes out of 2 -> convert to leader\n"
         "           replicate 1 new entry (2^3)\n"
         "           probe server 2 sending 1 entry (2^3)\n");

--- a/test/integration/test_start.c
+++ b/test/integration/test_start.c
@@ -89,7 +89,7 @@ TEST_V1(raft_start, PersistedTermAndSnapshot, setUp, tearDown, 0, NULL)
                          2, /* last term                                 */
                          2, /* N servers                                 */
                          2, /* N voting                                  */
-                         1 /* conf index                                */);
+                         1 /* conf index                                 */);
     CLUSTER_START(1 /* ID */);
     CLUSTER_TRACE("[   0] 1 > term 2, 1 snapshot (6^2)\n");
     return MUNIT_OK;

--- a/test/lib/cluster.h
+++ b/test/lib/cluster.h
@@ -237,6 +237,8 @@ static bool v1 = false;
         munit_error("trace does not match");           \
     }
 
+#define CLUSTER_ELAPSE(MSECS) test_cluster_elapse(&f->cluster_, MSECS)
+
 /* Step the cluster. */
 #define CLUSTER_STEP raft_fixture_step(&f->cluster);
 
@@ -744,6 +746,10 @@ void test_cluster_submit(struct test_cluster *c,
 /* Advance the cluster by completing a single asynchronous operation or firing a
  * timeout. */
 void test_cluster_step(struct test_cluster *c);
+
+/* Let the given number of milliseconds elapse. This requires that no event
+ * would be triggered by test_cluster_step() in the given time window. */
+void test_cluster_elapse(struct test_cluster *c, unsigned msecs);
 
 /* Stop delivering messages from id1 to id2 */
 void test_cluster_disconnect(struct test_cluster *c, raft_id id1, raft_id id2);


### PR DESCRIPTION
These tests now only use the v1 API and the associated test cluster machinery.