### PR TITLE
replication: Don't delay replication after a failed probe

### DIFF
--- a/test/integration/test_snapshot.c
+++ b/test/integration/test_snapshot.c
@@ -187,7 +187,7 @@ TEST(snapshot,
     (void)params;
 
     /* Set very low threshold and trailing entries number */
-    SET_SNAPSHOT_THRESHOLD(3);
+    SET_SNAPSHOT_THRESHOLD(4);
     SET_SNAPSHOT_TRAILING(1);
     SET_SNAPSHOT_TIMEOUT(200);
 
@@ -231,7 +231,7 @@ TEST(snapshot,
     (void)params;
 
     /* Set very low threshold and trailing entries number */
-    SET_SNAPSHOT_THRESHOLD(3);
+    SET_SNAPSHOT_THRESHOLD(4);
     SET_SNAPSHOT_TRAILING(1);
     SET_SNAPSHOT_TIMEOUT(200);
 


### PR DESCRIPTION
Some call sites require to skip the progressShouldReplicate() check and force triggering replication immediately. For if probing a server fails because of missing entries, the leader should retry immediately without waiting for the heartbeat timeout to expire.