### PR TITLE
recv: Check remote term early on when handling RequestVote responses

### DIFF
--- a/test/integration/test_election.c
+++ b/test/integration/test_election.c
@@ -330,7 +330,7 @@ TEST_V1(election, RejectIfHigherTerm, setUp, tearDown, 0, NULL)
     CLUSTER_TRACE(
         "[ 120] 1 > recv request vote result from server 2\n"
         "           remote term is higher (3 vs 2) -> bump term, step down\n"
-        "           no longer candidate -> ignore\n");
+        "           local server is follower -> ignore\n");
 
     munit_assert_int(raft_state(CLUSTER_RAFT(1)), ==, RAFT_FOLLOWER);
 


### PR DESCRIPTION
When handling a RequestVote response, immediately check the term of the remote peer, before doing anything else.

This avoids checking if we are in candidate state twice, once at the beginning of the message handling and once after the term check, to handle the case where we step down.

Also, decide whether to perform an actual term bump or just a check based on the pre-vote flag of the RequestVote response being handled, and not based on whether we are in pre-vote phase or not. That's because we always want to bump our term if for any reason we discover an higher term (e.g. we receive a delayed non pre-vote response containing a newer term while in the meantime we have transitioned to pre-vote phase).