### PR TITLE
byte: Use `uint8_t*` instead of `void*` to meet aliasing rules

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -60,6 +60,9 @@ AM_CONDITIONAL(BENCHMARK_ENABLED, test "x$enable_benchmark" = "xyes")
 AC_ARG_ENABLE(debug, AS_HELP_STRING([--enable-debug[=ARG]], [enable debugging [default=no]]))
 AM_CONDITIONAL(DEBUG_ENABLED, test "x$enable_debug" = "xyes")
 
+# Whether to enable compile-time hardening options.
+AC_ARG_ENABLE(hardening, AS_HELP_STRING([--disable-hardening], [disable compile-time hardening options]))
+
 # Whether to enable memory sanitizer.
 AC_ARG_ENABLE(sanitize, AS_HELP_STRING([--enable-sanitize[=ARG]], [enable code sanitizers [default=no]]))
 AM_CONDITIONAL(SANITIZE_ENABLED, test x"$enable_sanitize" = x"yes")
@@ -102,57 +105,63 @@ AC_TYPE_UINT64_T
 # on 32-bit architecture be 8 bytes instead of the normal 4.
 AC_SYS_LARGEFILE
 
-CC_CHECK_FLAGS_APPEND([AM_CFLAGS],[CFLAGS],[ \
-  -std=c11 \
-  -g \
-  --mcet \
-  -fcf-protection \
-  --param=ssp-buffer-size=4 \
-  -pipe \
-  -fdiagnostics-color \
-  -fexceptions \
-  -fstack-clash-protection \
-  -fstack-protector-strong \
-  -fasynchronous-unwind-tables \
-  -fdiagnostics-show-option \
-  -Wall \
-  -Wextra \
-  -Wpedantic \
-  -Wimplicit-fallthrough=5 \
-  -Wcast-align \
-  -Wstrict-prototypes \
-  -Wlogical-op \
-  -Wmissing-include-dirs \
-  -Wold-style-definition \
-  -Winit-self \
-  -Wfloat-equal \
-  -Wsuggest-attribute=noreturn \
-  -Wformat=2 \
-  -Wendif-labels \
-  -Wdate-time \
-  -Wnested-externs \
-  -Wconversion \
-  -Werror=implicit-function-declaration \
-  -Wunused-but-set-variable \
-  -Werror=return-type \
-  -Werror=incompatible-pointer-types \
-  -Wshadow \
-  -Werror=overflow \
-  -Werror=shift-count-overflow \
-  -Werror=shift-overflow=2 \
-  -Warray-bounds \
-  -Wrestrict \
-  -Wreturn-local-addr \
-  -Wstringop-overflow \
-])
+AS_IF([test "x$enable_hardening" != "xno"],
+      [CC_CHECK_FLAGS_APPEND([AM_CFLAGS],[CFLAGS],[ \
+        -std=c11 \
+        -g \
+        --mcet \
+        -fcf-protection \
+        --param=ssp-buffer-size=4 \
+        -pipe \
+        -fdiagnostics-color \
+        -fexceptions \
+        -fstack-clash-protection \
+        -fstack-protector-strong \
+        -fasynchronous-unwind-tables \
+        -fdiagnostics-show-option \
+        -Wall \
+        -Wextra \
+        -Wpedantic \
+        -Wimplicit-fallthrough=5 \
+        -Wcast-align \
+        -Wstrict-prototypes \
+        -Wlogical-op \
+        -Wmissing-include-dirs \
+        -Wold-style-definition \
+        -Winit-self \
+        -Wfloat-equal \
+        -Wsuggest-attribute=noreturn \
+        -Wformat=2 \
+        -Wendif-labels \
+        -Wdate-time \
+        -Wnested-externs \
+        -Wconversion \
+        -Werror=implicit-function-declaration \
+        -Wunused-but-set-variable \
+        -Werror=return-type \
+        -Werror=incompatible-pointer-types \
+        -Wshadow \
+        -Werror=overflow \
+        -Werror=shift-count-overflow \
+        -Werror=shift-overflow=2 \
+        -Warray-bounds \
+        -Wrestrict \
+        -Wreturn-local-addr \
+        -Wstringop-overflow \
+      ])],
+      [])
+
 AC_SUBST(AM_CFLAGS)
 
-CC_CHECK_FLAGS_APPEND([AM_LDFLAGS],[LDFLAGS],[ \
-  -z relro \
-  -z now \
-  -fstack-protector-strong \
-  --param=ssp-buffer-size=4 \
-])
+AS_IF([test "x$enable_hardening" != "xno"],
+      [CC_CHECK_FLAGS_APPEND([AM_LDFLAGS],[LDFLAGS],[ \
+        -z relro \
+        -z now \
+        -fstack-protector-strong \
+        --param=ssp-buffer-size=4 \
+      ])],
+      [])
+
 AC_SUBST(AM_LDLAGS)
 
 REQUIRES=''

--- a/configure.ac
+++ b/configure.ac
@@ -109,7 +109,6 @@ CC_CHECK_FLAGS_APPEND([AM_CFLAGS],[CFLAGS],[ \
   -fcf-protection \
   --param=ssp-buffer-size=4 \
   -pipe \
-  -fno-strict-aliasing \
   -fdiagnostics-color \
   -fexceptions \
   -fstack-clash-protection \

--- a/src/byte.h
+++ b/src/byte.h
@@ -74,14 +74,13 @@ BYTE__INLINE uint64_t byteFlip64(uint64_t v)
 #endif
 }
 
-BYTE__INLINE void bytePut8(void **cursor, uint8_t value)
+BYTE__INLINE void bytePut8(uint8_t **cursor, uint8_t value)
 {
-    uint8_t **p = (uint8_t **)cursor;
-    **p = value;
-    *p += 1;
+    **cursor = value;
+    *cursor += 1;
 }
 
-BYTE__INLINE void bytePut32(void **cursor, uint32_t value)
+BYTE__INLINE void bytePut32(uint8_t **cursor, uint32_t value)
 {
     unsigned i;
     uint32_t flipped = byteFlip32(value);
@@ -90,7 +89,7 @@ BYTE__INLINE void bytePut32(void **cursor, uint32_t value)
     }
 }
 
-BYTE__INLINE void bytePut64(void **cursor, uint64_t value)
+BYTE__INLINE void bytePut64(uint8_t **cursor, uint64_t value)
 {
     unsigned i;
     uint64_t flipped = byteFlip64(value);
@@ -99,22 +98,21 @@ BYTE__INLINE void bytePut64(void **cursor, uint64_t value)
     }
 }
 
-BYTE__INLINE void bytePutString(void **cursor, const char *value)
+BYTE__INLINE void bytePutString(uint8_t **cursor, const char *value)
 {
     char **p = (char **)cursor;
     strcpy(*p, value);
-    *p += strlen(value) + 1;
+    *cursor += strlen(value) + 1;
 }
 
-BYTE__INLINE uint8_t byteGet8(const void **cursor)
+BYTE__INLINE uint8_t byteGet8(const uint8_t **cursor)
 {
-    const uint8_t **p = (const uint8_t **)cursor;
-    uint8_t value = **p;
-    *p += 1;
+    uint8_t value = **cursor;
+    *cursor += 1;
     return value;
 }
 
-BYTE__INLINE uint32_t byteGet32(const void **cursor)
+BYTE__INLINE uint32_t byteGet32(const uint8_t **cursor)
 {
     uint32_t value = 0;
     unsigned i;
@@ -124,7 +122,7 @@ BYTE__INLINE uint32_t byteGet32(const void **cursor)
     return byteFlip32(value);
 }
 
-BYTE__INLINE uint64_t byteGet64(const void **cursor)
+BYTE__INLINE uint64_t byteGet64(const uint8_t **cursor)
 {
     uint64_t value = 0;
     unsigned i;
@@ -134,13 +132,12 @@ BYTE__INLINE uint64_t byteGet64(const void **cursor)
     return byteFlip64(value);
 }
 
-BYTE__INLINE const char *byteGetString(const void **cursor, size_t max_len)
+BYTE__INLINE const char *byteGetString(const uint8_t **cursor, size_t max_len)
 {
-    const char **p = (const char **)cursor;
-    const char *value = *p;
+    const char *value = (const char *)*cursor;
     size_t len = 0;
     while (len < max_len) {
-        if (*(*p + len) == 0) {
+        if (*(*cursor + len) == 0) {
             break;
         }
         len++;
@@ -148,7 +145,7 @@ BYTE__INLINE const char *byteGetString(const void **cursor, size_t max_len)
     if (len == max_len) {
         return NULL;
     }
-    *p += len + 1;
+    *cursor += len + 1;
     return value;
 }
 

--- a/src/compress.c
+++ b/src/compress.c
@@ -104,7 +104,7 @@ bool IsCompressed(const void *data, size_t sz)
     if (data == NULL || sz < 4) {
         return false;
     }
-    const void *cursor = data;
+    const uint8_t *cursor = data;
 #ifdef LZ4F_MAGICNUMBER
 #define RAFT_LZ4F_MAGICNUMBER LZ4F_MAGICNUMBER
 #else

--- a/src/configuration.c
+++ b/src/configuration.c
@@ -265,7 +265,7 @@ size_t configurationEncodedSize(const struct raft_configuration *c)
 
 void configurationEncodeToBuf(const struct raft_configuration *c, void *buf)
 {
-    void *cursor = buf;
+    uint8_t *cursor = buf;
     unsigned i;
 
     /* Encoding format version */
@@ -314,7 +314,7 @@ err:
 int configurationDecode(const struct raft_buffer *buf,
                         struct raft_configuration *c)
 {
-    const void *cursor;
+    const uint8_t *cursor;
     size_t i;
     size_t n;
     int rv;

--- a/src/uv_encoding.c
+++ b/src/uv_encoding.c
@@ -91,7 +91,7 @@ size_t uvSizeofBatchHeader(size_t n)
 
 static void encodeRequestVote(const struct raft_request_vote *p, void *buf)
 {
-    void *cursor = buf;
+    uint8_t *cursor = buf;
     uint64_t flags = 0;
 
     if (p->disrupt_leader) {
@@ -111,7 +111,7 @@ static void encodeRequestVote(const struct raft_request_vote *p, void *buf)
 static void encodeRequestVoteResult(const struct raft_request_vote_result *p,
                                     void *buf)
 {
-    void *cursor = buf;
+    uint8_t *cursor = buf;
     uint64_t flags = 0;
 
     if (p->pre_vote) {
@@ -125,7 +125,7 @@ static void encodeRequestVoteResult(const struct raft_request_vote_result *p,
 
 static void encodeAppendEntries(const struct raft_append_entries *p, void *buf)
 {
-    void *cursor;
+    uint8_t *cursor;
 
     cursor = buf;
 
@@ -144,7 +144,7 @@ static void encodeAppendEntriesResult(
     const struct raft_append_entries_result *p,
     void *buf)
 {
-    void *cursor = buf;
+    uint8_t *cursor = buf;
 
     bytePut64(&cursor, p->term);
     bytePut64(&cursor, p->rejected);
@@ -155,7 +155,7 @@ static void encodeAppendEntriesResult(
 static void encodeInstallSnapshot(const struct raft_install_snapshot *p,
                                   void *buf)
 {
-    void *cursor;
+    uint8_t *cursor;
     size_t conf_size = configurationEncodedSize(&p->conf);
 
     cursor = buf;
@@ -176,7 +176,7 @@ static void encodeInstallSnapshot(const struct raft_install_snapshot *p,
 
 static void encodeTimeoutNow(const struct raft_timeout_now *p, void *buf)
 {
-    void *cursor = buf;
+    uint8_t *cursor = buf;
 
     bytePut64(&cursor, p->term);
     bytePut64(&cursor, p->last_log_index);
@@ -188,7 +188,7 @@ int uvEncodeMessage(const struct raft_message *message,
                     unsigned *n_bufs)
 {
     uv_buf_t header;
-    void *cursor;
+    uint8_t *cursor;
 
     /* Figure out the length of the header for this request and allocate a
      * buffer for it. */
@@ -221,7 +221,7 @@ int uvEncodeMessage(const struct raft_message *message,
         goto oom;
     }
 
-    cursor = header.base;
+    cursor = (uint8_t *)header.base;
 
     /* Encode the request preamble, with message type and message size. */
     bytePut64(&cursor, message->type);
@@ -297,7 +297,7 @@ void uvEncodeBatchHeader(const struct raft_entry *entries,
                          void *buf)
 {
     unsigned i;
-    void *cursor = buf;
+    uint8_t *cursor = buf;
 
     /* Number of entries in the batch, little endian */
     bytePut64(&cursor, n);
@@ -320,9 +320,9 @@ void uvEncodeBatchHeader(const struct raft_entry *entries,
 
 static void decodeRequestVote(const uv_buf_t *buf, struct raft_request_vote *p)
 {
-    const void *cursor;
+    const uint8_t *cursor;
 
-    cursor = buf->base;
+    cursor = (void *)buf->base;
 
     p->version = 1;
     p->term = byteGet64(&cursor);
@@ -345,9 +345,9 @@ static void decodeRequestVote(const uv_buf_t *buf, struct raft_request_vote *p)
 static void decodeRequestVoteResult(const uv_buf_t *buf,
                                     struct raft_request_vote_result *p)
 {
-    const void *cursor;
+    const uint8_t *cursor;
 
-    cursor = buf->base;
+    cursor = (void *)buf->base;
 
     p->version = 1;
     p->term = byteGet64(&cursor);
@@ -364,7 +364,7 @@ int uvDecodeBatchHeader(const void *batch,
                         struct raft_entry **entries,
                         unsigned *n)
 {
-    const void *cursor = batch;
+    const uint8_t *cursor = batch;
     size_t i;
     int rv;
 
@@ -415,13 +415,13 @@ err:
 static int decodeAppendEntries(const uv_buf_t *buf,
                                struct raft_append_entries *args)
 {
-    const void *cursor;
+    const uint8_t *cursor;
     int rv;
 
     assert(buf != NULL);
     assert(args != NULL);
 
-    cursor = buf->base;
+    cursor = (void *)buf->base;
 
     args->version = 0;
     args->term = byteGet64(&cursor);
@@ -440,9 +440,9 @@ static int decodeAppendEntries(const uv_buf_t *buf,
 static void decodeAppendEntriesResult(const uv_buf_t *buf,
                                       struct raft_append_entries_result *p)
 {
-    const void *cursor;
+    const uint8_t *cursor;
 
-    cursor = buf->base;
+    cursor = (void *)buf->base;
 
     p->version = 0;
     p->term = byteGet64(&cursor);
@@ -458,14 +458,14 @@ static void decodeAppendEntriesResult(const uv_buf_t *buf,
 static int decodeInstallSnapshot(const uv_buf_t *buf,
                                  struct raft_install_snapshot *args)
 {
-    const void *cursor;
+    const uint8_t *cursor;
     struct raft_buffer conf;
     int rv;
 
     assert(buf != NULL);
     assert(args != NULL);
 
-    cursor = buf->base;
+    cursor = (void *)buf->base;
 
     args->version = 0;
     args->term = byteGet64(&cursor);
@@ -487,9 +487,9 @@ static int decodeInstallSnapshot(const uv_buf_t *buf,
 
 static void decodeTimeoutNow(const uv_buf_t *buf, struct raft_timeout_now *p)
 {
-    const void *cursor;
+    const uint8_t *cursor;
 
-    cursor = buf->base;
+    cursor = (void *)buf->base;
 
     p->version = 0;
     p->term = byteGet64(&cursor);

--- a/src/uv_fs.c
+++ b/src/uv_fs.c
@@ -729,7 +729,7 @@ static int probeAsyncIO(int fd, size_t size, bool *ok, char *errmsg)
     /* Prepare the KAIO request object */
     memset(&iocb, 0, sizeof iocb);
     iocb.aio_lio_opcode = IOCB_CMD_PWRITE;
-    *((void **)(&iocb.aio_buf)) = buf;
+    iocb.aio_buf = (uintptr_t)buf;
     iocb.aio_nbytes = size;
     iocb.aio_offset = 0;
     iocb.aio_fildes = (uint32_t)fd;

--- a/src/uv_metadata.c
+++ b/src/uv_metadata.c
@@ -13,7 +13,7 @@
 /* Encode the content of a metadata file. */
 static void uvMetadataEncode(const struct uvMetadata *metadata, void *buf)
 {
-    void *cursor = buf;
+    uint8_t *cursor = buf;
     bytePut64(&cursor, UV__DISK_FORMAT);
     bytePut64(&cursor, metadata->version);
     bytePut64(&cursor, metadata->term);
@@ -25,7 +25,7 @@ static int uvMetadataDecode(const void *buf,
                             struct uvMetadata *metadata,
                             char *errmsg)
 {
-    const void *cursor = buf;
+    const uint8_t *cursor = buf;
     uint64_t format;
     format = byteGet64(&cursor);
     if (format != UV__DISK_FORMAT) {

--- a/src/uv_segment.c
+++ b/src/uv_segment.c
@@ -699,7 +699,7 @@ void uvSegmentBufferClose(struct uvSegmentBuffer *b)
 int uvSegmentBufferFormat(struct uvSegmentBuffer *b)
 {
     int rv;
-    void *cursor;
+    uint8_t *cursor;
     size_t n;
     assert(b->n == 0);
     n = sizeof(uint64_t);
@@ -708,7 +708,7 @@ int uvSegmentBufferFormat(struct uvSegmentBuffer *b)
         return rv;
     }
     b->n = n;
-    cursor = b->arena.base;
+    cursor = (uint8_t *)b->arena.base;
     bytePut64(&cursor, UV__DISK_FORMAT);
     return 0;
 }
@@ -717,13 +717,13 @@ int uvSegmentBufferAppend(struct uvSegmentBuffer *b,
                           const struct raft_entry entries[],
                           unsigned n_entries)
 {
-    size_t size;   /* Total size of the batch */
-    uint32_t crc1; /* Header checksum */
-    uint32_t crc2; /* Data checksum */
-    void *crc1_p;  /* Pointer to header checksum slot */
-    void *crc2_p;  /* Pointer to data checksum slot */
-    void *header;  /* Pointer to the header section */
-    void *cursor;
+    size_t size;     /* Total size of the batch */
+    uint32_t crc1;   /* Header checksum */
+    uint32_t crc2;   /* Data checksum */
+    uint8_t *crc1_p; /* Pointer to header checksum slot */
+    uint8_t *crc2_p; /* Pointer to data checksum slot */
+    void *header;    /* Pointer to the header section */
+    uint8_t *cursor;
     unsigned i;
     int rv;
 
@@ -737,7 +737,7 @@ int uvSegmentBufferAppend(struct uvSegmentBuffer *b,
     if (rv != 0) {
         return rv;
     }
-    cursor = b->arena.base + b->n;
+    cursor = (uint8_t *)b->arena.base + b->n;
 
     /* Placeholder of the checksums */
     crc1_p = cursor;

--- a/src/uv_snapshot.c
+++ b/src/uv_snapshot.c
@@ -611,7 +611,7 @@ int UvSnapshotPut(struct raft_io *io,
 {
     struct uv *uv;
     struct uvSnapshotPut *put;
-    void *cursor;
+    uint8_t *cursor;
     unsigned crc;
     int rv;
     raft_index next_index;
@@ -650,7 +650,7 @@ int UvSnapshotPut(struct raft_io *io,
         goto err_after_req_alloc;
     }
 
-    cursor = put->meta.header;
+    cursor = (uint8_t *)put->meta.header;
     bytePut64(&cursor, UV__DISK_FORMAT);
     bytePut64(&cursor, 0);
     bytePut64(&cursor, snapshot->configuration_index);
@@ -659,7 +659,7 @@ int UvSnapshotPut(struct raft_io *io,
     crc = byteCrc32(&put->meta.header[2], sizeof(uint64_t) * 2, 0);
     crc = byteCrc32(put->meta.bufs[1].base, put->meta.bufs[1].len, crc);
 
-    cursor = &put->meta.header[1];
+    cursor = (uint8_t *)&put->meta.header[1];
     bytePut64(&cursor, crc);
 
     /* - If the trailing parameter is set to 0, it means that we're restoring a

--- a/src/uv_tcp_connect.c
+++ b/src/uv_tcp_connect.c
@@ -51,7 +51,7 @@ struct uvTcpConnect
 /* Encode an handshake message into the given buffer. */
 static int uvTcpEncodeHandshake(raft_id id, const char *address, uv_buf_t *buf)
 {
-    void *cursor;
+    uint8_t *cursor;
     size_t address_len = bytePad64(strlen(address) + 1);
     buf->len = sizeof(uint64_t) + /* Protocol version. */
                sizeof(uint64_t) + /* Server ID. */
@@ -61,11 +61,11 @@ static int uvTcpEncodeHandshake(raft_id id, const char *address, uv_buf_t *buf)
     if (buf->base == NULL) {
         return RAFT_NOMEM;
     }
-    cursor = buf->base;
+    cursor = (uint8_t *)buf->base;
     bytePut64(&cursor, UV__TCP_HANDSHAKE_PROTOCOL);
     bytePut64(&cursor, id);
     bytePut64(&cursor, address_len);
-    strcpy(cursor, address);
+    strcpy((char *)cursor, address);
     return 0;
 }
 

--- a/src/uv_writer.c
+++ b/src/uv_writer.c
@@ -190,7 +190,7 @@ static void uvWriterPollCb(uv_poll_t *poller, int status, int events)
 
     for (i = 0; i < (unsigned)n_events; i++) {
         struct io_event *event = &w->events[i];
-        struct UvWriterReq *req = *((void **)&event->data);
+        struct UvWriterReq *req = (void *)((uintptr_t)event->data);
 
         /* If we got EAGAIN, it means it was not possible to perform the write
          * asynchronously, so let's fall back to the threadpool. */
@@ -472,10 +472,10 @@ int UvWriterSubmit(struct UvWriter *w,
     req->iocb.aio_fildes = (uint32_t)w->fd;
     req->iocb.aio_lio_opcode = IOCB_CMD_PWRITEV;
     req->iocb.aio_reqprio = 0;
-    *((void **)(&req->iocb.aio_buf)) = (void *)bufs;
+    req->iocb.aio_buf = (uintptr_t)bufs;
     req->iocb.aio_nbytes = n;
     req->iocb.aio_offset = (int64_t)offset;
-    *((void **)(&req->iocb.aio_data)) = (void *)req;
+    req->iocb.aio_data = (uintptr_t)req;
 
     /* Use per-request synchronous I/O if available. */
     req->iocb.aio_rw_flags |= RWF_DSYNC;

--- a/test/integration/test_uv_init.c
+++ b/test/integration/test_uv_init.c
@@ -67,7 +67,7 @@ static void closeCb(struct raft_io *io)
 #define WRITE_METADATA_FILE(N, FORMAT, VERSION, TERM, VOTED_FOR) \
     {                                                            \
         uint8_t buf[8 * 4];                                      \
-        void *cursor = buf;                                      \
+        uint8_t *cursor = buf;                                   \
         char filename[strlen("metadataN") + 1];                  \
         sprintf(filename, "metadata%d", N);                      \
         bytePut64(&cursor, FORMAT);                              \

--- a/test/integration/test_uv_set_term.c
+++ b/test/integration/test_uv_set_term.c
@@ -69,7 +69,7 @@ static void closeCb(struct raft_io *io)
 #define WRITE_METADATA_FILE(N, FORMAT, VERSION, TERM, VOTED_FOR) \
     {                                                            \
         uint8_t buf[8 * 4];                                      \
-        void *cursor = buf;                                      \
+        uint8_t *cursor = buf;                                   \
         char filename[strlen("metadataN") + 1];                  \
         sprintf(filename, "metadata%d", N);                      \
         bytePut64(&cursor, FORMAT);                              \
@@ -81,17 +81,17 @@ static void closeCb(struct raft_io *io)
 
 /* Assert that the content of either the metadata1 or metadata2 file match the
  * given values. */
-#define ASSERT_METADATA_FILE(N, VERSION, TERM, VOTED_FOR)    \
-    {                                                        \
-        uint8_t buf2[8 * 4];                                 \
-        const void *cursor = buf2;                           \
-        char filename[strlen("metadataN") + 1];              \
-        sprintf(filename, "metadata%d", N);                  \
-        DirReadFile(f->dir, filename, buf2, sizeof buf2);    \
-        munit_assert_int(byteGet64(&cursor), ==, 1);         \
-        munit_assert_int(byteGet64(&cursor), ==, VERSION);   \
-        munit_assert_int(byteGet64(&cursor), ==, TERM);      \
-        munit_assert_int(byteGet64(&cursor), ==, VOTED_FOR); \
+#define ASSERT_METADATA_FILE(N, VERSION, TERM, VOTED_FOR)       \
+    {                                                           \
+        uint8_t buf2[8 * 4];                                    \
+        const uint8_t *cursor = buf2;                           \
+        char filename[strlen("metadataN") + 1];                 \
+        sprintf(filename, "metadata%d", N);                     \
+        DirReadFile(f->dir, filename, buf2, sizeof buf2);       \
+        munit_assert_ullong(byteGet64(&cursor), ==, 1);         \
+        munit_assert_ullong(byteGet64(&cursor), ==, VERSION);   \
+        munit_assert_ullong(byteGet64(&cursor), ==, TERM);      \
+        munit_assert_ullong(byteGet64(&cursor), ==, VOTED_FOR); \
     }
 
 /******************************************************************************

--- a/test/integration/test_uv_tcp_listen.c
+++ b/test/integration/test_uv_tcp_listen.c
@@ -116,7 +116,7 @@ static void tearDownDeps(void *data)
 static void *setUp(const MunitParameter params[], void *user_data)
 {
     struct fixture *f = setUpDeps(params, user_data);
-    void *cursor;
+    uint8_t *cursor;
     /* test_tcp_listen(&f->tcp); */
     INIT;
     f->accepted = false;
@@ -126,7 +126,7 @@ static void *setUp(const MunitParameter params[], void *user_data)
     bytePut64(&cursor, 1);
     bytePut64(&cursor, PEER_ID);
     bytePut64(&cursor, 16);
-    strcpy(cursor, PEER_ADDRESS);
+    strcpy((char *)cursor, PEER_ADDRESS);
 
     return f;
 }

--- a/test/lib/fsm.c
+++ b/test/lib/fsm.c
@@ -20,7 +20,7 @@ static int fsmApply(struct raft_fsm *fsm,
                     void **result)
 {
     struct fsm *f = fsm->data;
-    const void *cursor = buf->base;
+    const uint8_t *cursor = buf->base;
     unsigned command;
     int value;
 
@@ -56,9 +56,9 @@ static int fsmApply(struct raft_fsm *fsm,
 static int fsmRestore(struct raft_fsm *fsm, struct raft_buffer *buf)
 {
     struct fsm *f = fsm->data;
-    const void *cursor = buf->base;
+    const uint8_t *cursor = buf->base;
 
-    munit_assert_int(buf->len, ==, sizeof(uint64_t) * 2);
+    munit_assert_ullong(buf->len, ==, sizeof(uint64_t) * 2);
 
     f->x = byteGet64(&cursor);
     f->y = byteGet64(&cursor);
@@ -74,7 +74,7 @@ static int fsmEncodeSnapshot(int x,
                              unsigned *n_bufs)
 {
     struct raft_buffer *buf;
-    void *cursor;
+    uint8_t *cursor;
 
     *n_bufs = 1;
 
@@ -172,7 +172,7 @@ void FsmClose(struct raft_fsm *fsm)
 
 void FsmEncodeSetX(const int value, struct raft_buffer *buf)
 {
-    void *cursor;
+    uint8_t *cursor;
 
     buf->base = raft_malloc(16);
     buf->len = 16;
@@ -186,7 +186,7 @@ void FsmEncodeSetX(const int value, struct raft_buffer *buf)
 
 void FsmEncodeAddX(const int value, struct raft_buffer *buf)
 {
-    void *cursor;
+    uint8_t *cursor;
 
     buf->base = raft_malloc(16);
     buf->len = 16;
@@ -200,7 +200,7 @@ void FsmEncodeAddX(const int value, struct raft_buffer *buf)
 
 void FsmEncodeSetY(const int value, struct raft_buffer *buf)
 {
-    void *cursor;
+    uint8_t *cursor;
 
     buf->base = raft_malloc(16);
     buf->len = 16;
@@ -214,7 +214,7 @@ void FsmEncodeSetY(const int value, struct raft_buffer *buf)
 
 void FsmEncodeAddY(const int value, struct raft_buffer *buf)
 {
-    void *cursor;
+    uint8_t *cursor;
 
     buf->base = raft_malloc(16);
     buf->len = 16;

--- a/test/unit/test_byte.c
+++ b/test/unit/test_byte.c
@@ -81,7 +81,7 @@ SUITE(byteGetString)
 TEST(byteGetString, success, NULL, NULL, 0, NULL)
 {
     uint8_t buf[] = {'h', 'e', 'l', 'l', 'o', 0};
-    const void *cursor = buf;
+    const uint8_t *cursor = buf;
     munit_assert_string_equal(byteGetString(&cursor, sizeof buf), "hello");
     munit_assert_ptr_equal(cursor, buf + sizeof buf);
     return MUNIT_OK;
@@ -90,7 +90,7 @@ TEST(byteGetString, success, NULL, NULL, 0, NULL)
 TEST(byteGetString, malformed, NULL, NULL, 0, NULL)
 {
     uint8_t buf[] = {'h', 'e', 'l', 'l', 'o', 'w'};
-    const void *cursor = buf;
+    const uint8_t *cursor = buf;
     munit_assert_ptr_equal(byteGetString(&cursor, sizeof buf), NULL);
     munit_assert_ptr_equal(cursor, buf);
     return MUNIT_OK;
@@ -107,10 +107,10 @@ SUITE(byteGet64)
 TEST(byteGet64, success, NULL, NULL, 0, NULL)
 {
     uint8_t *buf = munit_malloc(sizeof(uint64_t) * 2);
-    void *cursor1 = buf + 1;
-    const void *cursor2 = buf + 1;
+    uint8_t *cursor1 = buf + 1;
+    const uint8_t *cursor2 = buf + 1;
     bytePut64(&cursor1, 1);
-    munit_assert_int(byteGet64(&cursor2), ==, 1);
+    munit_assert_ullong(byteGet64(&cursor2), ==, 1);
     free(buf);
     return MUNIT_OK;
 }

--- a/test/unit/test_configuration.c
+++ b/test/unit/test_configuration.c
@@ -428,7 +428,7 @@ TEST(configurationEncode, one_server, setUp, tearDown, 0, NULL)
     struct fixture *f = data;
     struct raft_buffer buf;
     size_t len;
-    const void *cursor;
+    const uint8_t *cursor;
     const char *address = "127.0.0.1:666";
     ADD(1, address, RAFT_VOTER);
     ENCODE(&buf);
@@ -437,14 +437,14 @@ TEST(configurationEncode, one_server, setUp, tearDown, 0, NULL)
           8 + strlen(address) + 1; /* Server */
     len = bytePad64(len);
 
-    munit_assert_int(buf.len, ==, len);
+    munit_assert_ullong(buf.len, ==, len);
 
     cursor = buf.base;
 
     munit_assert_int(byteGet8(&cursor), ==, 1);
-    munit_assert_int(byteGet64(&cursor), ==, 1);
+    munit_assert_ullong(byteGet64(&cursor), ==, 1);
 
-    munit_assert_int(byteGet64(&cursor), ==, 1);
+    munit_assert_ullong(byteGet64(&cursor), ==, 1);
     munit_assert_string_equal(byteGetString(&cursor, strlen(address) + 1),
                               address);
     munit_assert_int(byteGet8(&cursor), ==, RAFT_VOTER);
@@ -460,7 +460,7 @@ TEST(configurationEncode, two_servers, setUp, tearDown, 0, NULL)
     struct fixture *f = data;
     struct raft_buffer buf;
     size_t len;
-    const void *cursor;
+    const uint8_t *cursor;
     const char *address1 = "127.0.0.1:666";
     const char *address2 = "192.168.1.1:666";
 
@@ -473,19 +473,19 @@ TEST(configurationEncode, two_servers, setUp, tearDown, 0, NULL)
           8 + strlen(address2) + 1 + 1;  /* Server 2 */
     len = bytePad64(len);
 
-    munit_assert_int(buf.len, ==, len);
+    munit_assert_ullong(buf.len, ==, len);
 
     cursor = buf.base;
 
     munit_assert_int(byteGet8(&cursor), ==, 1);
-    munit_assert_int(byteGet64(&cursor), ==, 2);
+    munit_assert_ullong(byteGet64(&cursor), ==, 2);
 
-    munit_assert_int(byteGet64(&cursor), ==, 1);
+    munit_assert_ullong(byteGet64(&cursor), ==, 1);
     munit_assert_string_equal(byteGetString(&cursor, strlen(address1) + 1),
                               address1);
     munit_assert_int(byteGet8(&cursor), ==, RAFT_STANDBY);
 
-    munit_assert_int(byteGet64(&cursor), ==, 2);
+    munit_assert_ullong(byteGet64(&cursor), ==, 2);
     munit_assert_string_equal(byteGetString(&cursor, strlen(address2) + 1),
                               address2);
     munit_assert_int(byteGet8(&cursor), ==, RAFT_VOTER);


### PR DESCRIPTION
Fixes #125.