### PR TITLE
build: Separate regular and desired gcc options from hardening ones

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -105,13 +105,16 @@ AC_TYPE_UINT64_T
 # on 32-bit architecture be 8 bytes instead of the normal 4.
 AC_SYS_LARGEFILE
 
+CC_CHECK_FLAGS_APPEND([AM_CFLAGS],[CFLAGS],[ \
+  -std=c11 \
+  -g \
+  -pipe \
+])
+
 AS_IF([test "x$enable_hardening" != "xno"],
       [CC_CHECK_FLAGS_APPEND([AM_CFLAGS],[CFLAGS],[ \
-        -std=c11 \
-        -g \
         -fcf-protection \
         --param=ssp-buffer-size=4 \
-        -pipe \
         -fdiagnostics-color \
         -fexceptions \
         -fstack-clash-protection \

--- a/configure.ac
+++ b/configure.ac
@@ -109,7 +109,6 @@ AS_IF([test "x$enable_hardening" != "xno"],
       [CC_CHECK_FLAGS_APPEND([AM_CFLAGS],[CFLAGS],[ \
         -std=c11 \
         -g \
-        --mcet \
         -fcf-protection \
         --param=ssp-buffer-size=4 \
         -pipe \


### PR DESCRIPTION
Flags like -std and -pipe will be used unconditionally if available.
