### PR TITLE
v1: Add `raft_transferee()` API and associated internal logic changes

### DIFF
--- a/include/raft.h
+++ b/include/raft.h
@@ -805,7 +805,7 @@ struct raft_log;
         unsigned random; /* Pseudo-random number generator state */          \
         struct raft_message *messages; /* Pre-allocated message queue */     \
         unsigned n_messages_cap;       /* Capacity of the message queue */   \
-        unsigned unused;               /* XXX: For backward ABI compat */    \
+        unsigned unused1;              /* XXX: For backward ABI compat */    \
         /* Index of the last snapshot that was taken */                      \
         raft_index configuration_last_snapshot_index;                        \
         /* Fields used by the v0 compatibility code */                       \
@@ -1023,8 +1023,7 @@ struct raft
      * of voting servers. */
     raft_time election_timer_start;
 
-    /* In-progress leadership transfer request, if any. */
-    struct raft_transfer *transfer;
+    struct raft_transfer *transfer; /* Used by the legacy compatibility layer */
 
     /*
      * Information about the last snapshot that was taken (if any).

--- a/include/raft.h
+++ b/include/raft.h
@@ -995,12 +995,12 @@ struct raft
         struct
         {
             struct raft_progress *progress; /* Per-server replication state. */
-            struct raft_change *change;     /* XXX: unused, for ABI compat. */
+            struct raft_change *unused1;    /* XXX: unused, for ABI compat. */
             raft_id promotee_id;            /* ID of server being promoted. */
             unsigned short round_number;    /* Current sync round. */
             raft_index round_index;         /* Target of the current round. */
             raft_time round_start;          /* Start of current round. */
-            void *requests[2];              /* XXX: unused, for ABI compat. */
+            void *unused2[2];               /* XXX: unused, for ABI compat. */
             union {
                 uint64_t reserved[8]; /* Future use */
                 struct

--- a/include/raft.h
+++ b/include/raft.h
@@ -1001,7 +1001,15 @@ struct raft
             raft_index round_index;         /* Target of the current round. */
             raft_time round_start;          /* Start of current round. */
             void *requests[2];              /* XXX: unused, for ABI compat. */
-            uint64_t reserved[8];           /* Future use */
+            union {
+                uint64_t reserved[8]; /* Future use */
+                struct
+                {
+                    raft_id transferee; /* Server ID of aleadership transfer */
+                    raft_time transfer_start;
+                    bool transferring; /* True if after sending TimeoutNow */
+                };
+            };
         } leader_state;
     };
 

--- a/include/raft.h
+++ b/include/raft.h
@@ -1138,6 +1138,12 @@ enum {
 RAFT_API int raft_catch_up(const struct raft *r, raft_id id, int *status);
 
 /**
+ * Return the ID of the server that leadership is being transfered to, or #0 if
+ * no leadership transfer is in progress.
+ */
+RAFT_API raft_id raft_transferee(const struct raft *r);
+
+/**
  * Bootstrap this raft instance using the given configuration. The instance
  * must not have been started yet and must be completely pristine, otherwise
  * #RAFT_CANTBOOTSTRAP will be returned.

--- a/include/raft.h
+++ b/include/raft.h
@@ -1106,23 +1106,23 @@ RAFT_API int raft_step(struct raft *r,
 /**
  * Return the current term of this server.
  */
-RAFT_API raft_term raft_current_term(struct raft *r);
+RAFT_API raft_term raft_current_term(const struct raft *r);
 
 /**
  * Return the ID of the server that this server has voted for, or #0 if it not
  * vote.
  */
-RAFT_API raft_id raft_voted_for(struct raft *r);
+RAFT_API raft_id raft_voted_for(const struct raft *r);
 
 /**
  * Return the commit index of this server.
  */
-RAFT_API raft_index raft_commit_index(struct raft *r);
+RAFT_API raft_index raft_commit_index(const struct raft *r);
 
 /**
  * Return the time at which the next RAFT_TIMEOUT event should be fired.
  */
-RAFT_API raft_time raft_timeout(struct raft *r);
+RAFT_API raft_time raft_timeout(const struct raft *r);
 
 /**
  * Return information about the progress of a server that is catching up with
@@ -1135,7 +1135,7 @@ enum {
     RAFT_CATCH_UP_FINISHED
 };
 
-RAFT_API int raft_catch_up(struct raft *r, raft_id id, int *status);
+RAFT_API int raft_catch_up(const struct raft *r, raft_id id, int *status);
 
 /**
  * Bootstrap this raft instance using the given configuration. The instance

--- a/src/convert.c
+++ b/src/convert.c
@@ -166,6 +166,10 @@ int convertToLeader(struct raft *r)
     r->leader_state.round_index = 0;
     r->leader_state.round_start = 0;
 
+    /* Reset leadership transfer. */
+    r->leader_state.transferee = 0;
+    r->leader_state.transferring = false;
+
     n_voters = configurationVoterCount(&r->configuration);
     assert(n_voters > 0);
 

--- a/src/convert.c
+++ b/src/convert.c
@@ -231,10 +231,6 @@ err:
 
 void convertToUnavailable(struct raft *r)
 {
-    /* Abort any pending leadership transfer request. */
-    if (r->transfer != NULL) {
-        membershipLeadershipTransferClose(r);
-    }
     convertClear(r);
     convertSetState(r, RAFT_UNAVAILABLE);
 }

--- a/src/election.c
+++ b/src/election.c
@@ -20,7 +20,8 @@ struct followerOrCandidateState
 };
 
 /* Return a pointer to either the follower or candidate state. */
-struct followerOrCandidateState *getFollowerOrCandidateState(struct raft *r)
+struct followerOrCandidateState *getFollowerOrCandidateState(
+    const struct raft *r)
 {
     struct followerOrCandidateState *state;
     assert(r->state == RAFT_FOLLOWER || r->state == RAFT_CANDIDATE);
@@ -56,7 +57,7 @@ bool electionTimerExpired(struct raft *r)
     return now - r->election_timer_start >= state->randomized_election_timeout;
 }
 
-raft_time electionTimerExpiration(struct raft *r)
+raft_time electionTimerExpiration(const struct raft *r)
 {
     struct followerOrCandidateState *state;
     assert(r->state == RAFT_FOLLOWER || r->state == RAFT_CANDIDATE);

--- a/src/election.h
+++ b/src/election.h
@@ -45,7 +45,7 @@ bool electionTimerExpired(struct raft *r);
 /* Return the time at which the election timer will expire next.
  *
  * Must be called in follower or candidate state. */
-raft_time electionTimerExpiration(struct raft *r);
+raft_time electionTimerExpiration(const struct raft *r);
 
 /* Start a new election round.
  *

--- a/src/legacy.h
+++ b/src/legacy.h
@@ -15,4 +15,10 @@ void LegacyFailPendingRequests(struct raft *r);
 /* Fire the callbacks of all completed client requests. */
 void LegacyFireCompletedRequests(struct raft *r);
 
+/* Initialize a leadership transfer request. */
+void LegacyLeadershipTransferInit(struct raft *r,
+                                  struct raft_transfer *req,
+                                  raft_id id,
+                                  raft_transfer_cb cb);
+
 #endif /* RAFT_LEGACY_H_ */

--- a/src/membership.h
+++ b/src/membership.h
@@ -46,18 +46,8 @@ int membershipUncommittedChange(struct raft *r,
  * from their log. */
 int membershipRollback(struct raft *r);
 
-/* Initialize the state of a leadership transfer request. */
-void membershipLeadershipTransferInit(struct raft *r,
-                                      struct raft_transfer *req,
-                                      raft_id id,
-                                      raft_transfer_cb cb);
-
 /* Start the leadership transfer by sending a TimeoutNow message to the target
  * server. */
 int membershipLeadershipTransferStart(struct raft *r);
-
-/* Finish a leadership transfer (whether successful or not), resetting the
- * leadership transfer state and firing the user callback. */
-void membershipLeadershipTransferClose(struct raft *r);
 
 #endif /* MEMBERSHIP_H_ */

--- a/src/progress.c
+++ b/src/progress.c
@@ -375,7 +375,7 @@ void progressCatchUpFinish(struct raft *r, unsigned i)
     p->catch_up = RAFT_CATCH_UP_FINISHED;
 }
 
-int progressCatchUpStatus(struct raft *r, unsigned i)
+int progressCatchUpStatus(const struct raft *r, unsigned i)
 {
     struct raft_progress *p = &r->leader_state.progress[i];
     return p->catch_up;

--- a/src/progress.h
+++ b/src/progress.h
@@ -155,6 +155,6 @@ void progressCatchUpAbort(struct raft *r, unsigned i);
 void progressCatchUpFinish(struct raft *r, unsigned i);
 
 /* Return the information about the catch-up progress of a server. */
-int progressCatchUpStatus(struct raft *r, unsigned i);
+int progressCatchUpStatus(const struct raft *r, unsigned i);
 
 #endif /* PROGRESS_H_ */

--- a/src/raft.c
+++ b/src/raft.c
@@ -628,6 +628,15 @@ int raft_catch_up(const struct raft *r, raft_id id, int *status)
     return 0;
 }
 
+raft_id raft_transferee(const struct raft *r)
+{
+    if (r->transfer == NULL) {
+        return 0;
+    }
+    assert(r->transfer->id != 0);
+    return r->transfer->id;
+}
+
 void raft_set_election_timeout(struct raft *r, const unsigned msecs)
 {
     r->election_timeout = msecs;

--- a/src/raft.c
+++ b/src/raft.c
@@ -543,23 +543,23 @@ out:
     return 0;
 }
 
-raft_term raft_current_term(struct raft *r)
+raft_term raft_current_term(const struct raft *r)
 {
     return r->current_term;
 }
 
-raft_term raft_voted_for(struct raft *r)
+raft_term raft_voted_for(const struct raft *r)
 {
     return r->voted_for;
 }
 
-raft_index raft_commit_index(struct raft *r)
+raft_index raft_commit_index(const struct raft *r)
 {
     return r->commit_index;
 }
 
 /* Return the time at which the next leader timeout should be triggered. */
-static raft_time leaderTimeout(struct raft *r)
+static raft_time leaderTimeout(const struct raft *r)
 {
     raft_time timeout;
     raft_time last_send = ULLONG_MAX;
@@ -589,7 +589,7 @@ static raft_time leaderTimeout(struct raft *r)
     return timeout;
 }
 
-raft_time raft_timeout(struct raft *r)
+raft_time raft_timeout(const struct raft *r)
 {
     raft_time timeout;
     switch (r->state) {
@@ -610,7 +610,7 @@ raft_time raft_timeout(struct raft *r)
     return timeout;
 }
 
-int raft_catch_up(struct raft *r, raft_id id, int *status)
+int raft_catch_up(const struct raft *r, raft_id id, int *status)
 {
     unsigned i;
 

--- a/src/recv.c
+++ b/src/recv.c
@@ -68,14 +68,6 @@ int recvMessage(struct raft *r,
         return rv;
     }
 
-    /* If there's a leadership transfer in progress, check if it has
-     * completed. */
-    if (r->transfer != NULL) {
-        if (r->follower_state.current_leader.id == r->transfer->id) {
-            membershipLeadershipTransferClose(r);
-        }
-    }
-
     return 0;
 }
 

--- a/src/state.c
+++ b/src/state.c
@@ -22,7 +22,7 @@ void raft_leader(struct raft *r, raft_id *id, const char **address)
             *address = r->follower_state.current_leader.address;
             return;
         case RAFT_LEADER:
-            if (r->transfer != NULL) {
+            if (r->leader_state.transferee != 0) {
                 *id = 0;
                 *address = NULL;
                 return;


### PR DESCRIPTION
A leadership transfer can now be carried on by firing a `RAFT_TRANSFER` event, without using `struct raft_transfer`, which is now kept only in the legacy backward compatibility layer.