### PR TITLE
v1: Drop RAFT_SENT event

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -21,7 +21,6 @@ libraft_la_SOURCES = \
   src/entry.c \
   src/err.c \
   src/heap.c \
-  src/log.c \
   src/membership.c \
   src/message.c \
   src/progress.c \
@@ -109,6 +108,7 @@ endif # LZ4_AVAILABLE
 
 if V0_ENABLED
 libraft_la_SOURCES += \
+  src/log.c \
   src/legacy.c \
   src/snapshot.c
 libraft_la_CFLAGS += -DV0_ENABLED

--- a/include/raft.h.in
+++ b/include/raft.h.in
@@ -454,8 +454,7 @@ enum {
     RAFT_STOP,
     RAFT_PERSISTED_ENTRIES,  /* A batch of entries have been persisted. */
     RAFT_PERSISTED_SNAPSHOT, /* A snapshot has been persisted. */
-    RAFT_SENT,    /* A message has been sent (either successfully or not). */
-    RAFT_RECEIVE, /* A message has been received. */
+    RAFT_RECEIVE,            /* A message has been received. */
     RAFT_CONFIGURATION, /* A new committed configuration must be applied. */
     RAFT_SNAPSHOT,      /* A snapshot has been taken. */
     RAFT_TIMEOUT,       /* The timeout has expired. */
@@ -498,11 +497,6 @@ struct raft_event
             bool last;
             int status;
         } persisted_snapshot;
-        struct
-        {
-            struct raft_message message;
-            int status;
-        } sent;
         struct
         {
             struct raft_message *message;

--- a/src/legacy.c
+++ b/src/legacy.c
@@ -28,7 +28,8 @@ static void legacySendMessageCb(struct raft_io_send *send, int status)
 {
     struct legacySendMessage *req = send->data;
     struct raft *r = req->r;
-    struct raft_event event;
+
+    (void)status;
 
     switch (req->message.type) {
         case RAFT_IO_APPEND_ENTRIES:
@@ -43,13 +44,7 @@ static void legacySendMessageCb(struct raft_io_send *send, int status)
             break;
     }
 
-    event.type = RAFT_SENT;
-    event.sent.message = req->message;
-    event.sent.status = status;
-
     raft_free(req);
-
-    LegacyForwardToRaftIo(r, &event);
 }
 
 static int legacyLoadSnapshot(struct legacySendMessage *req);
@@ -336,7 +331,6 @@ static void legacyLoadSnapshotCb(struct raft_io_snapshot_get *get,
     struct legacySendMessage *req = get->data;
     struct raft *r = req->r;
     struct raft_install_snapshot *params = &req->message.install_snapshot;
-    struct raft_event event;
     int rv;
 
     if (status != 0) {
@@ -373,13 +367,7 @@ abort:
     configurationClose(&params->conf);
     raft_free(params->data.base);
 
-    event.type = RAFT_SENT;
-    event.sent.message = req->message;
-    event.sent.status = status;
-
     raft_free(req);
-
-    LegacyForwardToRaftIo(r, &event);
 }
 
 static int legacyLoadSnapshot(struct legacySendMessage *req)

--- a/src/raft.c
+++ b/src/raft.c
@@ -413,22 +413,6 @@ static int stepPersistedSnapshot(struct raft *r,
     return 0;
 }
 
-/* Handle the completion of a send message operation. */
-static int stepSent(struct raft *r, struct raft_message *message, int status)
-{
-    int rv;
-    switch (message->type) {
-        case RAFT_IO_INSTALL_SNAPSHOT:
-            rv = replicationSendInstallSnapshotDone(r, message, status);
-            break;
-        default:
-            /* Ignore the status, in case of errors we'll retry. */
-            rv = 0;
-            break;
-    }
-    return rv;
-}
-
 /* Handle new messages. */
 static int stepReceive(struct raft *r, struct raft_message *message)
 {
@@ -518,7 +502,7 @@ int raft_step(struct raft *r,
                                        event->persisted_snapshot.status);
             break;
         case RAFT_SENT:
-            rv = stepSent(r, &event->sent.message, event->sent.status);
+            rv = 0;
             break;
         case RAFT_RECEIVE:
             rv = stepReceive(r, event->receive.message);

--- a/src/raft.c
+++ b/src/raft.c
@@ -501,9 +501,6 @@ int raft_step(struct raft *r,
                                        event->persisted_snapshot.last,
                                        event->persisted_snapshot.status);
             break;
-        case RAFT_SENT:
-            rv = 0;
-            break;
         case RAFT_RECEIVE:
             rv = stepReceive(r, event->receive.message);
             break;

--- a/src/raft.c
+++ b/src/raft.c
@@ -418,9 +418,6 @@ static int stepSent(struct raft *r, struct raft_message *message, int status)
 {
     int rv;
     switch (message->type) {
-        case RAFT_IO_APPEND_ENTRIES:
-            rv = replicationSendAppendEntriesDone(r, message, status);
-            break;
         case RAFT_IO_INSTALL_SNAPSHOT:
             rv = replicationSendInstallSnapshotDone(r, message, status);
             break;

--- a/src/raft.c
+++ b/src/raft.c
@@ -12,7 +12,6 @@
 #include "entry.h"
 #include "err.h"
 #include "heap.h"
-#include "log.h"
 #include "membership.h"
 #include "progress.h"
 #include "queue.h"
@@ -26,6 +25,7 @@
 
 #ifndef RAFT__LEGACY_no
 #include "legacy.h"
+#include "log.h"
 #endif
 
 #define DEFAULT_ELECTION_TIMEOUT 1000          /* One second */
@@ -154,8 +154,10 @@ int raft_init(struct raft *r,
 #endif
     return 0;
 
+#ifndef RAFT__LEGACY_no
 err_after_address_alloc:
     RaftHeapFree(r->address);
+#endif
 err:
     assert(rv != 0);
     return rv;

--- a/src/recv.c
+++ b/src/recv.c
@@ -4,7 +4,6 @@
 #include "convert.h"
 #include "entry.h"
 #include "heap.h"
-#include "log.h"
 #include "membership.h"
 #include "message.h"
 #include "recv_append_entries.h"

--- a/src/replication.c
+++ b/src/replication.c
@@ -37,27 +37,6 @@
  * TODO: Make this number configurable. */
 #define MAX_APPEND_ENTRIES 32
 
-/* Callback invoked after request to send an AppendEntries RPC has completed. */
-int replicationSendAppendEntriesDone(struct raft *r,
-                                     struct raft_message *message,
-                                     int status)
-{
-    unsigned i = configurationIndexOf(&r->configuration, message->server_id);
-
-    if (r->state == RAFT_LEADER && i < r->configuration.n) {
-        if (status != 0) {
-            tracef("failed to send append entries to server %llu: %s",
-                   message->server_id, raft_strerror(status));
-            /* Go back to probe mode. */
-            if (progressState(r, i) != PROGRESS__PROBE) {
-                progressToProbe(r, i);
-            }
-        }
-    }
-
-    return 0;
-}
-
 /* Send an AppendEntries message to the i'th server, including all log entries
  * from the given point onwards. */
 static int sendAppendEntries(struct raft *r,

--- a/src/replication.c
+++ b/src/replication.c
@@ -122,26 +122,6 @@ err:
     return rv;
 }
 
-int replicationSendInstallSnapshotDone(struct raft *r,
-                                       struct raft_message *message,
-                                       int status)
-{
-    const struct raft_server *server;
-
-    server = configurationGet(&r->configuration, message->server_id);
-
-    if (status != 0) {
-        tracef("send install snapshot: %s", raft_strerror(status));
-        if (r->state == RAFT_LEADER && server != NULL) {
-            unsigned i;
-            i = configurationIndexOf(&r->configuration, message->server_id);
-            progressAbortSnapshot(r, i);
-        }
-    }
-
-    return 0;
-}
-
 /* Send the latest snapshot to the i'th server */
 static int sendSnapshot(struct raft *r, const unsigned i)
 {

--- a/src/replication.h
+++ b/src/replication.h
@@ -82,11 +82,6 @@ int replicationInstallSnapshot(struct raft *r,
 /* Returns `true` if the raft instance is currently installing a snapshot */
 bool replicationInstallSnapshotBusy(struct raft *r);
 
-/* Called when an enqueued AppendEntries message has been processed. */
-int replicationSendAppendEntriesDone(struct raft *r,
-                                     struct raft_message *message,
-                                     int status);
-
 /* Called when an enqueued InstallSnapshot message has been processed. */
 int replicationSendInstallSnapshotDone(struct raft *r,
                                        struct raft_message *message,

--- a/src/replication.h
+++ b/src/replication.h
@@ -82,11 +82,6 @@ int replicationInstallSnapshot(struct raft *r,
 /* Returns `true` if the raft instance is currently installing a snapshot */
 bool replicationInstallSnapshotBusy(struct raft *r);
 
-/* Called when an enqueued InstallSnapshot message has been processed. */
-int replicationSendInstallSnapshotDone(struct raft *r,
-                                       struct raft_message *message,
-                                       int status);
-
 /* Called when handling a RAFT_PERSISTED_ENTRIES event. */
 int replicationPersistEntriesDone(struct raft *r,
                                   raft_index index,

--- a/src/restore.c
+++ b/src/restore.c
@@ -4,7 +4,6 @@
 #include "convert.h"
 #include "entry.h"
 #include "err.h"
-#include "log.h"
 #include "tracing.h"
 #include "trail.h"
 

--- a/src/snapshot.c
+++ b/src/snapshot.c
@@ -6,7 +6,6 @@
 #include "assert.h"
 #include "configuration.h"
 #include "err.h"
-#include "log.h"
 #include "tracing.h"
 
 #define tracef(...) Tracef(r->tracer, __VA_ARGS__)

--- a/src/state.c
+++ b/src/state.c
@@ -1,8 +1,8 @@
 #include "assert.h"
 #include "configuration.h"
 #include "election.h"
-#include "log.h"
 #include "queue.h"
+#include "trail.h"
 
 int raft_state(struct raft *r)
 {
@@ -35,7 +35,7 @@ void raft_leader(struct raft *r, raft_id *id, const char **address)
 
 raft_index raft_last_index(struct raft *r)
 {
-    return logLastIndex(r->legacy.log);
+    return TrailLastIndex(&r->trail);
 }
 
 raft_index raft_last_applied(struct raft *r)

--- a/src/tick.c
+++ b/src/tick.c
@@ -125,10 +125,17 @@ static bool checkContactQuorum(struct raft *r)
         }
 
         if (!is_recent) {
-            if (progressState(r, i) == PROGRESS__PIPELINE) {
-                infof("server %llu is unreachable -> abort pipeline",
-                      server->id);
-                progressToProbe(r, i);
+            switch (progressState(r, i)) {
+                case PROGRESS__PIPELINE:
+                    infof("server %llu is unreachable -> abort pipeline",
+                          server->id);
+                    progressToProbe(r, i);
+                    break;
+                case PROGRESS__SNAPSHOT:
+                    infof("server %llu is unreachable -> abort snapshot",
+                          server->id);
+                    progressAbortSnapshot(r, i);
+                    break;
             }
         }
     }

--- a/src/tick.c
+++ b/src/tick.c
@@ -123,6 +123,14 @@ static bool checkContactQuorum(struct raft *r)
         if ((server->role == RAFT_VOTER && is_recent) || server->id == r->id) {
             contacts++;
         }
+
+        if (!is_recent) {
+            if (progressState(r, i) == PROGRESS__PIPELINE) {
+                infof("server %llu is unreachable -> abort pipeline",
+                      server->id);
+                progressToProbe(r, i);
+            }
+        }
     }
 
     return contacts > configurationVoterCount(&r->configuration) / 2;

--- a/test/integration/test_election.c
+++ b/test/integration/test_election.c
@@ -1058,8 +1058,9 @@ TEST_V1(election, StartElectionWithUnpersistedEntries, setUp, tearDown, 0, NULL)
     CLUSTER_TRACE(
         "[ 240] 1 > recv append entries result from server 4\n"
         "[ 270] 1 > timeout as leader\n"
+        "           server 3 is unreachable -> abort pipeline\n"
         "           probe server 2 sending 2 entries (2^2..3^2)\n"
-        "           pipeline server 3 sending a heartbeat (no entries)\n"
+        "           probe server 3 sending a heartbeat (no entries)\n"
         "           pipeline server 4 sending a heartbeat (no entries)\n"
         "[ 280] 4 > recv append entries from server 1\n"
         "           no new entries to persist\n"

--- a/test/integration/test_membership.c
+++ b/test/integration/test_membership.c
@@ -320,12 +320,12 @@ TEST_V1(raft_remove, Committed, setup, tear_down, 0, NULL)
     ASSERT_CONFIGURATION_INDEXES(1, 1 /* committed */, 2 /* uncomitted */);
 
     CLUSTER_TRACE(
-        "[ 130] 1 > persisted 1 entry (2^2)\n"
-        "           next uncommitted entry (2^2) has 1 vote out of 2\n"
         "[ 130] 2 > recv append entries from server 1\n"
         "           no new entries to persist\n"
         "[ 130] 3 > recv append entries from server 1\n"
         "           no new entries to persist\n"
+        "[ 130] 1 > persisted 1 entry (2^2)\n"
+        "           next uncommitted entry (2^2) has 1 vote out of 2\n"
         "[ 140] 1 > recv append entries result from server 2\n"
         "           pipeline server 2 sending 1 entry (2^2)\n"
         "[ 140] 1 > recv append entries result from server 3\n"
@@ -478,12 +478,12 @@ TEST_V1(raft_remove, SelfThreeNodeCluster, setup, tear_down, 0, NULL)
 
     /* The removed leader eventually steps down */
     CLUSTER_TRACE(
-        "[ 130] 1 > persisted 1 entry (2^2)\n"
-        "           next uncommitted entry (2^2) has 0 votes out of 2\n"
         "[ 130] 2 > recv append entries from server 1\n"
         "           no new entries to persist\n"
         "[ 130] 3 > recv append entries from server 1\n"
         "           no new entries to persist\n"
+        "[ 130] 1 > persisted 1 entry (2^2)\n"
+        "           next uncommitted entry (2^2) has 0 votes out of 2\n"
         "[ 140] 1 > recv append entries result from server 2\n"
         "           pipeline server 2 sending 1 entry (2^2)\n"
         "[ 140] 1 > recv append entries result from server 3\n"

--- a/test/integration/test_replication.c
+++ b/test/integration/test_replication.c
@@ -389,8 +389,6 @@ TEST_V1(replication, Probe, setUp, tearDown, 0, NULL)
         "[ 130] 2 > recv append entries from server 1\n"
         "           no new entries to persist\n");
 
-    test_cluster_step(&f->cluster_);
-
     /* Server 1 receives a new entry after a few milliseconds. Since the
      * follower is still in probe mode and since an AppendEntries message was
      * already sent recently, it does not send the new entry immediately. */
@@ -431,7 +429,6 @@ TEST_V1(replication, Probe, setUp, tearDown, 0, NULL)
     /* Server 1 receives a second entry. Since the follower is still in probe
      * mode and since an AppendEntries message was already sent recently, it
      * does not send the new entry immediately. */
-    test_cluster_step(&f->cluster_);
     CLUSTER_ELAPSE(5);
     entry.buf.base = raft_malloc(entry.buf.len);
     munit_assert_not_null(entry.buf.base);
@@ -517,7 +514,6 @@ TEST_V1(replication, Pipeline, setUp, tearDown, 0, NULL)
         "[ 165] 2 > persisted 1 entry (2^2)\n"
         "           send success result to 1\n");
 
-    test_cluster_step(&f->cluster_);
     CLUSTER_ELAPSE(5);
     entry.buf.base = raft_malloc(8);
     munit_assert_not_null(entry.buf.base);

--- a/test/integration/test_snapshot.c
+++ b/test/integration/test_snapshot.c
@@ -624,10 +624,10 @@ TEST_V1(snapshot, NewTermWhileInstalling, setUp, tearDown, 0, NULL)
     CLUSTER_TRACE(
         "[ 120] 1 > submit 1 new client entry\n"
         "           replicate 1 new command entry (2^2)\n"
-        "[ 130] 1 > persisted 1 entry (2^2)\n"
-        "           next uncommitted entry (2^2) has 1 vote out of 3\n"
         "[ 130] 2 > recv append entries from server 1\n"
         "           no new entries to persist\n"
+        "[ 130] 1 > persisted 1 entry (2^2)\n"
+        "           next uncommitted entry (2^2) has 1 vote out of 3\n"
         "[ 140] 1 > recv append entries result from server 2\n"
         "           pipeline server 2 sending 1 entry (2^2)\n"
         "[ 150] 2 > recv append entries from server 1\n"

--- a/test/integration/test_snapshot.c
+++ b/test/integration/test_snapshot.c
@@ -673,6 +673,7 @@ TEST_V1(snapshot, NewTermWhileInstalling, setUp, tearDown, 0, NULL)
         "[ 210] 1 > timeout as leader\n"
         "           server 2 is unreachable -> abort pipeline\n"
         "[ 230] 1 > timeout as leader\n"
+        "           server 3 is unreachable -> abort snapshot\n"
         "           unable to contact majority of cluster -> step down\n");
 
     /* Let server 2 win the elections */

--- a/test/integration/test_snapshot.c
+++ b/test/integration/test_snapshot.c
@@ -671,6 +671,7 @@ TEST_V1(snapshot, NewTermWhileInstalling, setUp, tearDown, 0, NULL)
 
     CLUSTER_TRACE(
         "[ 210] 1 > timeout as leader\n"
+        "           server 2 is unreachable -> abort pipeline\n"
         "[ 230] 1 > timeout as leader\n"
         "           unable to contact majority of cluster -> step down\n");
 

--- a/test/lib/cluster.c
+++ b/test/lib/cluster.c
@@ -535,15 +535,16 @@ done:
 static void serverTruncateEntries(struct test_server *s, raft_index index)
 {
     unsigned i;
+    unsigned n = s->log.n;
 
-    if (index == s->log.start + s->log.n) {
+    if (index == s->log.start + n) {
         return;
     }
 
     munit_assert_ulong(index, >=, s->log.start);
-    munit_assert_ulong(index, <=, s->log.start + s->log.n);
+    munit_assert_ulong(index, <=, s->log.start + n);
 
-    for (i = (unsigned)(index - s->log.start); i < s->log.n; i++) {
+    for (i = (unsigned)(index - s->log.start); i < n; i++) {
         free(s->log.entries[i].buf.base);
         s->log.n--;
     }

--- a/test/lib/cluster.c
+++ b/test/lib/cluster.c
@@ -374,12 +374,6 @@ static void serverInit(struct test_server *s,
 
 static void serverStep(struct test_server *s, struct raft_event *event);
 
-static void serverCancelSend(struct test_server *s, struct step *step)
-{
-    step->event.sent.status = RAFT_CANCELED;
-    serverStep(s, &step->event);
-}
-
 static void serverCancelEntries(struct test_server *s, struct step *step)
 {
     struct raft_event *event = &step->event;
@@ -447,9 +441,6 @@ static void serverCancelPending(struct test_server *s)
         }
 
         switch (step->event.type) {
-            case RAFT_SENT:
-                serverCancelSend(s, step);
-                break;
             case RAFT_PERSISTED_ENTRIES:
                 serverCancelEntries(s, step);
                 break;

--- a/test/lib/cluster.c
+++ b/test/lib/cluster.c
@@ -936,27 +936,22 @@ static void serverCompleteSnapshot(struct test_server *s, struct step *step)
 
 static void serverCompleteSend(struct test_server *s, struct step *step)
 {
-    struct raft_event *event = &step->event;
     queue *head;
-    int status = 0;
+    bool connected = true;
 
     /* Check if there's a disconnection. */
     QUEUE_FOREACH (head, &s->cluster->disconnect) {
         struct disconnect *d = QUEUE_DATA(head, struct disconnect, queue);
         if (d->id1 == s->raft.id &&
             d->id2 == step->event.sent.message.server_id) {
-            status = RAFT_NOCONNECTION;
+            connected = false;
             break;
         }
     }
 
-    if (status == 0) {
+    if (connected) {
         serverEnqueueReceive(s, &step->event.sent.message);
     }
-
-    event->sent.status = status;
-
-    serverStep(s, event);
 }
 
 static void serverCompleteReceive(struct test_server *s, struct step *step)

--- a/test/lib/cluster.c
+++ b/test/lib/cluster.c
@@ -383,15 +383,19 @@ static void serverCancelEntries(struct test_server *s, struct step *step)
     struct raft_event *event = &step->event;
     raft_index index = event->persisted_entries.index;
 
+    event->time = s->cluster->time;
     event->persisted_entries.batch = &s->log.entries[index - s->log.start];
-    step->event.persisted_entries.status = RAFT_CANCELED;
+    event->persisted_entries.status = RAFT_CANCELED;
+
     serverStep(s, &step->event);
 }
 
 static void serverCancelSnapshot(struct test_server *s, struct step *step)
 {
     struct raft_event *event = &step->event;
-    step->event.persisted_snapshot.status = RAFT_CANCELED;
+
+    event->time = s->cluster->time;
+    event->persisted_snapshot.status = RAFT_CANCELED;
 
     /* XXX: this should probably be done by raft core */
     raft_free(event->persisted_snapshot.chunk.base);

--- a/test/lib/cluster.c
+++ b/test/lib/cluster.c
@@ -319,7 +319,6 @@ static void serverInit(struct test_server *s,
                        raft_id id,
                        struct test_cluster *cluster)
 {
-    char address[64];
     unsigned delta;
     int rv;
 
@@ -328,9 +327,9 @@ static void serverInit(struct test_server *s,
     s->tracer.emit = serverEmit;
     s->randomized_election_timeout_prev = 0;
 
-    sprintf(address, "%llu", id);
+    sprintf(s->address, "%llu", id);
 
-    rv = raft_init(&s->raft, NULL, NULL, id, address);
+    rv = raft_init(&s->raft, NULL, NULL, id, s->address);
     munit_assert_int(rv, ==, 0);
 
     s->raft.tracer = &s->tracer;
@@ -888,7 +887,7 @@ static void serverEnqueueReceive(struct test_server *s,
     event->receive.message = munit_malloc(sizeof *event->receive.message);
     *event->receive.message = *message;
     event->receive.message->server_id = s->raft.id;
-    event->receive.message->server_address = s->raft.address;
+    event->receive.message->server_address = s->address;
 
     switch (message->type) {
         case RAFT_IO_APPEND_ENTRIES:

--- a/test/lib/cluster.h
+++ b/test/lib/cluster.h
@@ -190,6 +190,7 @@ struct test_server
     raft_time timeout;            /* Next scheduled timeout */
     unsigned network_latency;     /* Network latency */
     unsigned disk_latency;        /* Disk latency */
+    char address[8];              /* Server address */
     bool running;                 /* Whether the server is running */
 
     struct

--- a/test/lib/cluster.h
+++ b/test/lib/cluster.h
@@ -227,6 +227,7 @@ struct test_cluster
     bool in_tear_down;                                  /* Tearing down */
     char trace[8192];                                   /* Captured messages */
     void *steps[2];                                     /* Pending events */
+    void *send[2];                                      /* Pending messages */
     void *disconnect[2];                                /* Network faults */
 };
 


### PR DESCRIPTION
We are now using the `RAFT_SENT` event only to detect unreachable nodes, something that can be done by looking at the last contact time.