### PR TITLE
test: Add `CLUSTER_SUBMIT()` helper macro

### DIFF
--- a/test/integration/test_catch_up.c
+++ b/test/integration/test_catch_up.c
@@ -22,7 +22,7 @@ static void tearDown(void *data)
 SUITE(catch_up)
 
 /* Trying to catch-up an unresponsive server eventually fails. */
-TEST_V1(catch_up, Unresponsive, setUp, tearDown, 0, NULL)
+TEST(catch_up, Unresponsive, setUp, tearDown, 0, NULL)
 {
     struct fixture *f = data;
     struct raft_configuration configuration;

--- a/test/integration/test_election.c
+++ b/test/integration/test_election.c
@@ -50,7 +50,7 @@ static void tearDown(void *data)
 SUITE(election)
 
 /* Test a successful election with 2 voters. */
-TEST_V1(election, TwoVoters, setUp, tearDown, 0, NULL)
+TEST(election, TwoVoters, setUp, tearDown, 0, NULL)
 {
     struct fixture *f = data;
     unsigned id;
@@ -89,7 +89,7 @@ TEST_V1(election, TwoVoters, setUp, tearDown, 0, NULL)
 
 /* If we have already voted and the same candidate requests the vote again, the
  * vote is granted. */
-TEST_V1(election, GrantAgain, setUp, tearDown, 0, NULL)
+TEST(election, GrantAgain, setUp, tearDown, 0, NULL)
 {
     struct fixture *f = data;
     unsigned id;
@@ -142,7 +142,7 @@ TEST_V1(election, GrantAgain, setUp, tearDown, 0, NULL)
 }
 
 /* If the requester last log entry index is the same, the vote is granted. */
-TEST_V1(election, GrantIfLastIndexIsSame, setUp, tearDown, 0, NULL)
+TEST(election, GrantIfLastIndexIsSame, setUp, tearDown, 0, NULL)
 {
     struct fixture *f = data;
     unsigned id;
@@ -172,7 +172,7 @@ TEST_V1(election, GrantIfLastIndexIsSame, setUp, tearDown, 0, NULL)
 }
 
 /* If the requester last log entry index is higher, the vote is granted. */
-TEST_V1(election, GrantIfRemoteLastIndexIsHigher, setUp, tearDown, 0, NULL)
+TEST(election, GrantIfRemoteLastIndexIsHigher, setUp, tearDown, 0, NULL)
 {
     struct fixture *f = data;
 
@@ -203,7 +203,7 @@ TEST_V1(election, GrantIfRemoteLastIndexIsHigher, setUp, tearDown, 0, NULL)
 }
 
 /* If the requester last log entry term is higher, the vote is granted. */
-TEST_V1(election, GrantIfRemoteLastTermIsHigher, setUp, tearDown, 0, NULL)
+TEST(election, GrantIfRemoteLastTermIsHigher, setUp, tearDown, 0, NULL)
 {
     struct fixture *f = data;
 
@@ -237,7 +237,7 @@ TEST_V1(election, GrantIfRemoteLastTermIsHigher, setUp, tearDown, 0, NULL)
 
 /* If a candidate receives a vote request response granting the vote but the
  * quorum is not reached, it stays candidate. */
-TEST_V1(election, WaitQuorum, setUp, tearDown, 0, NULL)
+TEST(election, WaitQuorum, setUp, tearDown, 0, NULL)
 {
     struct fixture *f = data;
     unsigned id;
@@ -274,7 +274,7 @@ TEST_V1(election, WaitQuorum, setUp, tearDown, 0, NULL)
 }
 
 /* The vote request gets rejected if the term of the candidate is lower. */
-TEST_V1(election, RejectIfRemoteTermLower, setUp, tearDown, 0, NULL)
+TEST(election, RejectIfRemoteTermLower, setUp, tearDown, 0, NULL)
 {
     struct fixture *f = data;
 
@@ -313,7 +313,7 @@ TEST_V1(election, RejectIfRemoteTermLower, setUp, tearDown, 0, NULL)
 
 /* If the server already has a leader, the vote is not granted (even if the
  * request has a higher term). */
-TEST_V1(election, RejectIfHasLeader, setUp, tearDown, 0, NULL)
+TEST(election, RejectIfHasLeader, setUp, tearDown, 0, NULL)
 {
     struct fixture *f = data;
     unsigned id;
@@ -370,7 +370,7 @@ TEST_V1(election, RejectIfHasLeader, setUp, tearDown, 0, NULL)
 }
 
 /* If a server has already voted, vote is not granted. */
-TEST_V1(election, RejectIfAlreadyVoted, setUp, tearDown, 0, NULL)
+TEST(election, RejectIfAlreadyVoted, setUp, tearDown, 0, NULL)
 {
     struct fixture *f = data;
     unsigned id;
@@ -418,7 +418,7 @@ TEST_V1(election, RejectIfAlreadyVoted, setUp, tearDown, 0, NULL)
 
 /* If the requester last log entry term is lower than ours, the vote is not
  * granted. */
-TEST_V1(election, RejectIfRemoteLastTermIsLower, setUp, tearDown, 0, NULL)
+TEST(election, RejectIfRemoteLastTermIsLower, setUp, tearDown, 0, NULL)
 {
     struct fixture *f = data;
     unsigned i;
@@ -454,7 +454,7 @@ TEST_V1(election, RejectIfRemoteLastTermIsLower, setUp, tearDown, 0, NULL)
 
 /* If the requester last log entry index is lower, the vote is not
  * granted. */
-TEST_V1(election, RejectIfRemoteLastIndexIsLower, setUp, tearDown, 0, NULL)
+TEST(election, RejectIfRemoteLastIndexIsLower, setUp, tearDown, 0, NULL)
 {
     struct fixture *f = data;
     unsigned id;
@@ -489,7 +489,7 @@ TEST_V1(election, RejectIfRemoteLastIndexIsLower, setUp, tearDown, 0, NULL)
 }
 
 /* If we are not a voting server, the vote is not granted. */
-TEST_V1(election, RejectIfNotVoter, setUp, tearDown, 0, NULL)
+TEST(election, RejectIfNotVoter, setUp, tearDown, 0, NULL)
 {
     struct fixture *f = data;
     struct raft_message message;
@@ -529,7 +529,7 @@ TEST_V1(election, RejectIfNotVoter, setUp, tearDown, 0, NULL)
 }
 
 /* Non-voting servers are skipped when sending vote requests. */
-TEST_V1(election, SkipNonVoters, setUp, tearDown, 0, NULL)
+TEST(election, SkipNonVoters, setUp, tearDown, 0, NULL)
 {
     struct fixture *f = data;
     unsigned id;
@@ -569,7 +569,7 @@ TEST_V1(election, SkipNonVoters, setUp, tearDown, 0, NULL)
 /* If a candidate server receives a response indicating that the vote was not
  * granted, nothing happens (e.g. the server has already voted for someone
  * else). */
-TEST_V1(election, ReceiveRejectResult, setUp, tearDown, 0, NULL)
+TEST(election, ReceiveRejectResult, setUp, tearDown, 0, NULL)
 {
     struct fixture *f = data;
     unsigned id;
@@ -626,7 +626,7 @@ TEST_V1(election, ReceiveRejectResult, setUp, tearDown, 0, NULL)
 }
 
 /* Test an election round with two voters and pre-vote. */
-TEST_V1(election, PreVote, setUp, tearDown, 0, NULL)
+TEST(election, PreVote, setUp, tearDown, 0, NULL)
 {
     struct fixture *f = data;
     unsigned id;
@@ -682,7 +682,7 @@ TEST_V1(election, PreVote, setUp, tearDown, 0, NULL)
 }
 
 /* A candidate receives votes then crashes. */
-TEST_V1(election, PreVoteWithcandidateCrash, setUp, tearDown, 0, NULL)
+TEST(election, PreVoteWithcandidateCrash, setUp, tearDown, 0, NULL)
 {
     struct fixture *f = data;
     unsigned id;
@@ -790,7 +790,7 @@ TEST_V1(election, PreVoteWithcandidateCrash, setUp, tearDown, 0, NULL)
 
 /* Ensure delayed pre-vote responses are not counted towards the real election
  * quorum. */
-TEST_V1(election, PreVoteNoStaleVotes, setUp, tearDown, 0, NULL)
+TEST(election, PreVoteNoStaleVotes, setUp, tearDown, 0, NULL)
 {
     struct fixture *f = data;
     unsigned id;
@@ -875,7 +875,7 @@ TEST_V1(election, PreVoteNoStaleVotes, setUp, tearDown, 0, NULL)
  * in-memory log cache as opposed to the last persisted one two bad things would
  * happen.
  */
-TEST_V1(election, StartElectionWithUnpersistedEntries, setUp, tearDown, 0, NULL)
+TEST(election, StartElectionWithUnpersistedEntries, setUp, tearDown, 0, NULL)
 {
     struct fixture *f = data;
     unsigned i;

--- a/test/integration/test_election.c
+++ b/test/integration/test_election.c
@@ -936,7 +936,7 @@ TEST(election, StartElectionWithUnpersistedEntries, setUp, tearDown, 0, NULL)
     munit_assert_int(rv, ==, 0);
     entry.batch = entry.buf.base;
 
-    test_cluster_submit(&f->cluster_, 1, &entry);
+    CLUSTER_SUBMIT(1 /* ID */, &entry);
 
     CLUSTER_TRACE(
         "[ 130] 1 > submit 1 new client entry\n"
@@ -985,7 +985,7 @@ TEST(election, StartElectionWithUnpersistedEntries, setUp, tearDown, 0, NULL)
     raft_configuration_close(&configuration);
     entry.batch = entry.buf.base;
 
-    test_cluster_submit(&f->cluster_, 1, &entry);
+    CLUSTER_SUBMIT(1 /* ID */, &entry);
     CLUSTER_TRACE(
         "[ 170] 1 > submit 1 new client entry\n"
         "           replicate 1 new configuration entry (3^2)\n"

--- a/test/integration/test_membership.c
+++ b/test/integration/test_membership.c
@@ -50,7 +50,7 @@ SUITE(raft_add)
 
 /* After a request to add a new non-voting server is committed, the new
  * configuration is not marked as uncommitted anymore */
-TEST_V1(raft_add, Committed, setup, tear_down, 0, NULL)
+TEST(raft_add, Committed, setup, tear_down, 0, NULL)
 {
     struct fixture *f = data;
     struct raft *raft = CLUSTER_RAFT(1);
@@ -128,7 +128,7 @@ TEST_V1(raft_add, Committed, setup, tear_down, 0, NULL)
 
 /* Trying to add a server on a node which is not the leader results in an
  * error. */
-TEST_V1(raft_add, NotLeader, setup, tear_down, 0, NULL)
+TEST(raft_add, NotLeader, setup, tear_down, 0, NULL)
 {
     struct fixture *f = data;
     struct raft_configuration configuration;
@@ -179,7 +179,7 @@ TEST_V1(raft_add, NotLeader, setup, tear_down, 0, NULL)
 
 /* Trying to add a server while a configuration change is already in progress
  * results in an error. */
-TEST_V1(raft_add, Busy, setup, tear_down, 0, NULL)
+TEST(raft_add, Busy, setup, tear_down, 0, NULL)
 {
     struct fixture *f = data;
     struct raft_configuration configuration;
@@ -239,7 +239,7 @@ TEST_V1(raft_add, Busy, setup, tear_down, 0, NULL)
 
 /* Trying to add a server with an ID which is already in use results in an
  * error. */
-TEST_V1(raft_add, DuplicateId, setup, tear_down, 0, NULL)
+TEST(raft_add, DuplicateId, setup, tear_down, 0, NULL)
 {
     struct raft_configuration configuration;
     int rv;
@@ -264,7 +264,7 @@ SUITE(raft_remove)
 
 /* After a request to remove server is committed, the new configuration is not
  * marked as uncommitted anymore */
-TEST_V1(raft_remove, Committed, setup, tear_down, 0, NULL)
+TEST(raft_remove, Committed, setup, tear_down, 0, NULL)
 {
     struct fixture *f = data;
     struct raft *raft = CLUSTER_RAFT(1);
@@ -346,7 +346,7 @@ TEST_V1(raft_remove, Committed, setup, tear_down, 0, NULL)
 }
 
 /* A leader gets a request to remove itself. */
-TEST_V1(raft_remove, Self, setup, tear_down, 0, NULL)
+TEST(raft_remove, Self, setup, tear_down, 0, NULL)
 {
     struct fixture *f = data;
     struct raft_configuration configuration;
@@ -410,7 +410,7 @@ TEST_V1(raft_remove, Self, setup, tear_down, 0, NULL)
 }
 
 /* A leader gets a request to remove itself from a 3-node cluster */
-TEST_V1(raft_remove, SelfThreeNodeCluster, setup, tear_down, 0, NULL)
+TEST(raft_remove, SelfThreeNodeCluster, setup, tear_down, 0, NULL)
 {
     struct fixture *f = data;
     struct raft_configuration configuration;
@@ -513,7 +513,7 @@ SUITE(raft_assign)
 
 /* Trying to promote a server on a raft instance which is not the leader results
  * in an error. */
-TEST_V1(raft_assign, NotLeader, setup, tear_down, 0, NULL)
+TEST(raft_assign, NotLeader, setup, tear_down, 0, NULL)
 {
     struct fixture *f = data;
     struct raft_configuration configuration;

--- a/test/integration/test_replication.c
+++ b/test/integration/test_replication.c
@@ -586,7 +586,7 @@ TEST_V1(replication, Disconnect, setUp, tearDown, 0, NULL)
 }
 
 /* A follower disconnects while in pipeline mode. */
-TEST_V1(replication, DisconnectPipeline, setUp, tearDown, 0, NULL)
+TEST_V1(replication, PipelineDisconnect, setUp, tearDown, 0, NULL)
 {
     struct fixture *f = data;
     struct raft *raft;
@@ -1904,7 +1904,7 @@ TEST_V1(replication, NoLeaderAfterPersistingEntries, setUp, tearDown, 0, NULL)
 
 /* While pipelining entries, the leader receives an AppendEntries response with
  * a stale reject index. */
-TEST_V1(replication, StaleRejectedIndexPipeline, setUp, tearDown, 0, NULL)
+TEST_V1(replication, PipelineStaleRejectedIndex, setUp, tearDown, 0, NULL)
 {
     struct fixture *f = data;
     unsigned id;

--- a/test/integration/test_replication.c
+++ b/test/integration/test_replication.c
@@ -960,7 +960,7 @@ TEST(replication, RollbackConfigurationToInitial, setUp, tearDown, 0, NULL)
     munit_assert_int(rv, ==, 0);
     raft_configuration_encode(&conf, &entry.buf);
     munit_assert_int(rv, ==, 0);
-    CLUSTER_ADD_ENTRY_RAW(2 /* ID */, &entry);
+    CLUSTER_ADD_ENTRY(2 /* ID */, &entry);
     raft_free(entry.buf.base);
     raft_configuration_close(&conf);
 
@@ -1049,7 +1049,7 @@ TEST(replication, RollbackConfigurationToPrevious, setUp, tearDown, 0, NULL)
     raft_configuration_add(&conf, 3, "3", 2);
     rv = raft_configuration_encode(&conf, &entry.buf);
     munit_assert_int(rv, ==, 0);
-    CLUSTER_ADD_ENTRY_RAW(2, &entry);
+    CLUSTER_ADD_ENTRY(2, &entry);
     raft_configuration_close(&conf);
     raft_free(entry.buf.base);
 
@@ -1146,7 +1146,7 @@ TEST(replication, RollbackConfigurationToSnapshot, setUp, tearDown, 0, NULL)
     munit_assert_int(rv, ==, 0);
     rv = raft_configuration_encode(&conf, &entry.buf);
     munit_assert_int(rv, ==, 0);
-    CLUSTER_ADD_ENTRY_RAW(2 /* ID */, &entry);
+    CLUSTER_ADD_ENTRY(2 /* ID */, &entry);
     raft_configuration_close(&conf);
     raft_free(entry.buf.base);
 

--- a/test/integration/test_replication.c
+++ b/test/integration/test_replication.c
@@ -66,7 +66,7 @@ SUITE(replication)
 
 /* A leader doesn't send an initial no-op barrier entry if its committed index
  * is as big as its last log index. */
-TEST_V1(replication, NoInitialBarrier, setUp, tearDown, 0, NULL)
+TEST(replication, NoInitialBarrier, setUp, tearDown, 0, NULL)
 {
     struct fixture *f = data;
     unsigned id;
@@ -102,7 +102,7 @@ TEST_V1(replication, NoInitialBarrier, setUp, tearDown, 0, NULL)
 
 /* A leader sends an initial no-op barrier entry if its committed index
  * is behind its last log index. */
-TEST_V1(replication, InitialBarrier, setUp, tearDown, 0, NULL)
+TEST(replication, InitialBarrier, setUp, tearDown, 0, NULL)
 {
     struct fixture *f = data;
     unsigned id;
@@ -143,7 +143,7 @@ TEST_V1(replication, InitialBarrier, setUp, tearDown, 0, NULL)
 
 /* After receiving an AppendEntriesResult, a leader has set the feature flags of
  * a node. */
-TEST_V1(replication, FeatureFlags, setUp, tearDown, 0, NULL)
+TEST(replication, FeatureFlags, setUp, tearDown, 0, NULL)
 {
     struct fixture *f = data;
     unsigned id;
@@ -187,7 +187,7 @@ TEST_V1(replication, FeatureFlags, setUp, tearDown, 0, NULL)
 
 /* A leader keeps sending heartbeat messages at regular intervals to
  * maintain leadership. */
-TEST_V1(replication, Heartbeat, setUp, tearDown, 0, NULL)
+TEST(replication, Heartbeat, setUp, tearDown, 0, NULL)
 {
     struct fixture *f = data;
     unsigned id;
@@ -230,7 +230,7 @@ TEST_V1(replication, Heartbeat, setUp, tearDown, 0, NULL)
 
 /* If a leader replicates some entries during a given heartbeat interval, it
  * skips sending the heartbeat for that interval. */
-TEST_V1(replication, SkipHeartbeatIfEntriesHaveSent, setUp, tearDown, 0, NULL)
+TEST(replication, SkipHeartbeatIfEntriesHaveSent, setUp, tearDown, 0, NULL)
 {
     struct fixture *f = data;
     unsigned id;
@@ -275,7 +275,7 @@ TEST_V1(replication, SkipHeartbeatIfEntriesHaveSent, setUp, tearDown, 0, NULL)
     entry.buf.base = raft_malloc(entry.buf.len);
     munit_assert_not_null(entry.buf.base);
     entry.batch = entry.buf.base;
-    test_cluster_submit(&f->cluster_, 1, &entry);
+    CLUSTER_SUBMIT(1 /* ID */, &entry);
 
     CLUSTER_TRACE(
         "[ 145] 1 > submit 1 new client entry\n"
@@ -311,7 +311,7 @@ TEST_V1(replication, SkipHeartbeatIfEntriesHaveSent, setUp, tearDown, 0, NULL)
 }
 
 /* The leader doesn't send replication messages to idle servers. */
-TEST_V1(replication, SkipSpare, setUp, tearDown, 0, NULL)
+TEST(replication, SkipSpare, setUp, tearDown, 0, NULL)
 {
     struct fixture *f = data;
     struct raft_entry entry;
@@ -354,7 +354,7 @@ TEST_V1(replication, SkipSpare, setUp, tearDown, 0, NULL)
 
 /* A follower remains in probe mode until the leader receives a successful
  * AppendEntries response. */
-TEST_V1(replication, Probe, setUp, tearDown, 0, NULL)
+TEST(replication, Probe, setUp, tearDown, 0, NULL)
 {
     struct fixture *f = data;
     struct raft_entry entry;
@@ -452,7 +452,7 @@ TEST_V1(replication, Probe, setUp, tearDown, 0, NULL)
 
 /* A follower transitions to pipeline mode after the leader receives a
  * successful AppendEntries response from it. */
-TEST_V1(replication, Pipeline, setUp, tearDown, 0, NULL)
+TEST(replication, Pipeline, setUp, tearDown, 0, NULL)
 {
     struct fixture *f = data;
     struct raft_entry entry;
@@ -544,7 +544,7 @@ TEST_V1(replication, Pipeline, setUp, tearDown, 0, NULL)
 }
 
 /* A follower disconnects while in probe mode. */
-TEST_V1(replication, Disconnect, setUp, tearDown, 0, NULL)
+TEST(replication, Disconnect, setUp, tearDown, 0, NULL)
 {
     struct fixture *f = data;
     unsigned id;
@@ -586,7 +586,7 @@ TEST_V1(replication, Disconnect, setUp, tearDown, 0, NULL)
 }
 
 /* A follower disconnects while in pipeline mode. */
-TEST_V1(replication, PipelineDisconnect, setUp, tearDown, 0, NULL)
+TEST(replication, PipelineDisconnect, setUp, tearDown, 0, NULL)
 {
     struct fixture *f = data;
     struct raft *raft;
@@ -676,7 +676,7 @@ TEST_V1(replication, PipelineDisconnect, setUp, tearDown, 0, NULL)
 }
 
 /* Receive the same entry a second time, before the first has been persisted. */
-TEST_V1(replication, ReceiveSameEntryTwice, setUp, tearDown, 0, NULL)
+TEST(replication, ReceiveSameEntryTwice, setUp, tearDown, 0, NULL)
 {
     struct fixture *f = data;
     unsigned id;
@@ -738,7 +738,7 @@ TEST_V1(replication, ReceiveSameEntryTwice, setUp, tearDown, 0, NULL)
 }
 
 /* If the term in the request is stale, the server rejects it. */
-TEST_V1(replication, AppendEntriesRequestHasStaleTerm, setUp, tearDown, 0, NULL)
+TEST(replication, AppendEntriesRequestHasStaleTerm, setUp, tearDown, 0, NULL)
 {
     struct fixture *f = data;
     unsigned id;
@@ -818,7 +818,7 @@ TEST_V1(replication, AppendEntriesRequestHasStaleTerm, setUp, tearDown, 0, NULL)
 
 /* If the log of the receiving server is shorter than prevLogIndex, the request
  * is rejected . */
-TEST_V1(replication, FollowerHasMissingEntries, setUp, tearDown, 0, NULL)
+TEST(replication, FollowerHasMissingEntries, setUp, tearDown, 0, NULL)
 {
     struct fixture *f = data;
     unsigned id;
@@ -874,7 +874,7 @@ TEST_V1(replication, FollowerHasMissingEntries, setUp, tearDown, 0, NULL)
 /* If the term of the last log entry on the server is different from the one
  * in prevLogTerm, and value of prevLogIndex is greater than the server's commit
  * index (i.e. this is a normal inconsistency), we reject the request. */
-TEST_V1(replication, PrevLogTermMismatch, setUp, tearDown, 0, NULL)
+TEST(replication, PrevLogTermMismatch, setUp, tearDown, 0, NULL)
 {
     struct fixture *f = data;
     unsigned id;
@@ -934,7 +934,7 @@ TEST_V1(replication, PrevLogTermMismatch, setUp, tearDown, 0, NULL)
  * entry happens to be a configuration change. In that case the follower
  * discards the conflicting entry from its log and rolls back its configuration
  * to the initial one contained in the log entry at index 1. */
-TEST_V1(replication, RollbackConfigurationToInitial, setUp, tearDown, 0, NULL)
+TEST(replication, RollbackConfigurationToInitial, setUp, tearDown, 0, NULL)
 {
     struct fixture *f = data;
     unsigned id;
@@ -1020,7 +1020,7 @@ TEST_V1(replication, RollbackConfigurationToInitial, setUp, tearDown, 0, NULL)
  * configuration entry present. In that case the follower discards the
  * conflicting entry from its log and rolls back its configuration to the
  * committed one in the older configuration entry. */
-TEST_V1(replication, RollbackConfigurationToPrevious, setUp, tearDown, 0, NULL)
+TEST(replication, RollbackConfigurationToPrevious, setUp, tearDown, 0, NULL)
 {
     struct fixture *f = data;
     unsigned id;
@@ -1111,7 +1111,7 @@ TEST_V1(replication, RollbackConfigurationToPrevious, setUp, tearDown, 0, NULL)
  * configuration anymore. In that case the follower discards the conflicting
  * entry from its log and rolls back its configuration to the previous committed
  * one, which was cached when the snapshot was restored. */
-TEST_V1(replication, RollbackConfigurationToSnapshot, setUp, tearDown, 0, NULL)
+TEST(replication, RollbackConfigurationToSnapshot, setUp, tearDown, 0, NULL)
 {
     struct fixture *f = data;
     struct raft_entry entry;
@@ -1202,7 +1202,7 @@ TEST_V1(replication, RollbackConfigurationToSnapshot, setUp, tearDown, 0, NULL)
 
 /* A write log request is submitted for outstanding log entries. If some entries
  * are already existing in the log, they will be skipped. */
-TEST_V1(replication, SkipExistingEntries, setUp, tearDown, 0, NULL)
+TEST(replication, SkipExistingEntries, setUp, tearDown, 0, NULL)
 {
     struct fixture *f = data;
     struct raft_entry entry;
@@ -1283,7 +1283,7 @@ TEST_V1(replication, SkipExistingEntries, setUp, tearDown, 0, NULL)
 
 /* If the index and term of the last snapshot on the server matches prevLogIndex
  * and prevLogTerm the request is accepted. */
-TEST_V1(replication, MatchingLastSnapshot, setUp, tearDown, 0, NULL)
+TEST(replication, MatchingLastSnapshot, setUp, tearDown, 0, NULL)
 {
     struct fixture *f = data;
 
@@ -1332,7 +1332,7 @@ TEST_V1(replication, MatchingLastSnapshot, setUp, tearDown, 0, NULL)
 
 /* If a candidate server receives a request containing the same term as its
  * own, it it steps down to follower and accept the request . */
-TEST_V1(replication, CandidateRecvRequestWithSameTerm, setUp, tearDown, 0, NULL)
+TEST(replication, CandidateRecvRequestWithSameTerm, setUp, tearDown, 0, NULL)
 {
     struct fixture *f = data;
     unsigned id;
@@ -1393,12 +1393,7 @@ TEST_V1(replication, CandidateRecvRequestWithSameTerm, setUp, tearDown, 0, NULL)
 
 /* If a candidate server receives an append entries request contaning an higher
  * term than its own, it it steps down to follower and accept the request. */
-TEST_V1(replication,
-        CandidateRecvRequestWithHigherTerm,
-        setUp,
-        tearDown,
-        0,
-        NULL)
+TEST(replication, CandidateRecvRequestWithHigherTerm, setUp, tearDown, 0, NULL)
 {
     struct fixture *f = data;
     unsigned id;
@@ -1471,7 +1466,7 @@ TEST_V1(replication,
 
 /* If the server handling the response is not the leader, the result is
  * ignored. */
-TEST_V1(replication, ReceiveResultButNotLeader, setUp, tearDown, 0, NULL)
+TEST(replication, ReceiveResultButNotLeader, setUp, tearDown, 0, NULL)
 {
     struct fixture *f = data;
     unsigned id;
@@ -1525,7 +1520,7 @@ TEST_V1(replication, ReceiveResultButNotLeader, setUp, tearDown, 0, NULL)
 
 /* If the response has a term which is lower than the server's one, it's
  * ignored. */
-TEST_V1(replication, ReceiveResultWithLowerTerm, setUp, tearDown, 0, NULL)
+TEST(replication, ReceiveResultWithLowerTerm, setUp, tearDown, 0, NULL)
 {
     struct fixture *f = data;
     unsigned id;
@@ -1601,7 +1596,7 @@ TEST_V1(replication, ReceiveResultWithLowerTerm, setUp, tearDown, 0, NULL)
 
 /* If the response has a term which is higher than the server's one, step down
  * to follower. */
-TEST_V1(replication, ReceiveResultWithHigherTerm, setUp, tearDown, 0, NULL)
+TEST(replication, ReceiveResultWithHigherTerm, setUp, tearDown, 0, NULL)
 {
     struct fixture *f = data;
     unsigned id;
@@ -1685,12 +1680,7 @@ TEST_V1(replication, ReceiveResultWithHigherTerm, setUp, tearDown, 0, NULL)
  * commit_index. A new leader gets elected, with a higher commit index, and
  * sends an an entry to the old leader, that needs to update its commit_index
  * taking into account its lagging last_stored. */
-TEST_V1(replication,
-        LastStoredLaggingBehindCommitIndex,
-        setUp,
-        tearDown,
-        0,
-        NULL)
+TEST(replication, LastStoredLaggingBehindCommitIndex, setUp, tearDown, 0, NULL)
 {
     struct fixture *f = data;
     unsigned id;
@@ -1846,7 +1836,7 @@ TEST_V1(replication,
 
 /* A follower finds that is has no leader anymore after it completes persisting
  * entries. No AppendEntries RPC result is sent in that case. */
-TEST_V1(replication, NoLeaderAfterPersistingEntries, setUp, tearDown, 0, NULL)
+TEST(replication, NoLeaderAfterPersistingEntries, setUp, tearDown, 0, NULL)
 {
     struct fixture *f = data;
     unsigned id;
@@ -1904,7 +1894,7 @@ TEST_V1(replication, NoLeaderAfterPersistingEntries, setUp, tearDown, 0, NULL)
 
 /* While pipelining entries, the leader receives an AppendEntries response with
  * a stale reject index. */
-TEST_V1(replication, PipelineStaleRejectedIndex, setUp, tearDown, 0, NULL)
+TEST(replication, PipelineStaleRejectedIndex, setUp, tearDown, 0, NULL)
 {
     struct fixture *f = data;
     unsigned id;
@@ -1969,7 +1959,7 @@ TEST_V1(replication, PipelineStaleRejectedIndex, setUp, tearDown, 0, NULL)
 
 /* After having sent a snapshot and waiting for a response, the leader receives
  * an AppendEntries response with a stale reject index. */
-TEST_V1(replication, StaleRejectedIndexSnapshot, setUp, tearDown, 0, NULL)
+TEST(replication, StaleRejectedIndexSnapshot, setUp, tearDown, 0, NULL)
 {
     struct fixture *f = data;
     struct raft_configuration configuration;

--- a/test/integration/test_snapshot.c
+++ b/test/integration/test_snapshot.c
@@ -66,13 +66,7 @@ TEST(snapshot, Install, setUp, tearDown, 0, NULL)
 
     /* Submit an entry which will to force a snapshot to be taken. */
     CLUSTER_ELAPSE(10);
-    entry.term = 1;
-    entry.type = RAFT_COMMAND;
-    entry.buf.len = 8;
-    entry.buf.base = raft_malloc(entry.buf.len);
-    munit_assert_not_null(entry.buf.base);
-    entry.batch = entry.buf.base;
-    test_cluster_submit(&f->cluster_, 1, &entry);
+    CLUSTER_SUBMIT(1 /* ID */, COMMAND, 8 /* size */);
 
     CLUSTER_TRACE(
         "[  10] 1 > submit 1 new client entry\n"
@@ -147,13 +141,7 @@ TEST(snapshot, InstallTimeout, setUp, tearDown, 0, NULL)
 
     /* Submit an entry which will to force a snapshot to be taken. */
     CLUSTER_ELAPSE(10);
-    entry.term = 1;
-    entry.type = RAFT_COMMAND;
-    entry.buf.len = 8;
-    entry.buf.base = raft_malloc(entry.buf.len);
-    munit_assert_not_null(entry.buf.base);
-    entry.batch = entry.buf.base;
-    test_cluster_submit(&f->cluster_, 1, &entry);
+    CLUSTER_SUBMIT(1 /* ID */, COMMAND, 8 /* size */);
 
     CLUSTER_TRACE(
         "[  10] 1 > submit 1 new client entry\n"
@@ -229,13 +217,7 @@ TEST(snapshot, SkipOffline, setUp, tearDown, 0, NULL)
 
     /* Submit an entry which will to force a snapshot to be taken. */
     CLUSTER_ELAPSE(10);
-    entry.term = 1;
-    entry.type = RAFT_COMMAND;
-    entry.buf.len = 8;
-    entry.buf.base = raft_malloc(entry.buf.len);
-    munit_assert_not_null(entry.buf.base);
-    entry.batch = entry.buf.base;
-    test_cluster_submit(&f->cluster_, 1, &entry);
+    CLUSTER_SUBMIT(1 /* ID */, COMMAND, 8 /* size */);
 
     CLUSTER_TRACE(
         "[  10] 1 > submit 1 new client entry\n"
@@ -330,7 +312,6 @@ TEST(snapshot, AbortIfRejected, setUp, tearDown, 0, NULL)
 TEST(snapshot, ReceiveAppendEntriesWhileInstalling, setUp, tearDown, 0, NULL)
 {
     struct fixture *f = data;
-    struct raft_entry entry;
     unsigned id;
 
     /* Set a very low threshold and trailing entries number on server 1. */
@@ -373,18 +354,8 @@ TEST(snapshot, ReceiveAppendEntriesWhileInstalling, setUp, tearDown, 0, NULL)
         "           probe server 3 sending a heartbeat (no entries)\n");
 
     /* Apply a few of entries, to force a snapshot to be taken. */
-    entry.term = 2;
-    entry.type = RAFT_COMMAND;
-    entry.buf.len = 8;
-    entry.buf.base = raft_malloc(entry.buf.len);
-    munit_assert_not_null(entry.buf.base);
-    entry.batch = entry.buf.base;
-    test_cluster_submit(&f->cluster_, 1, &entry);
-
-    entry.buf.base = raft_malloc(entry.buf.len);
-    munit_assert_not_null(entry.buf.base);
-    entry.batch = entry.buf.base;
-    test_cluster_submit(&f->cluster_, 1, &entry);
+    CLUSTER_SUBMIT(1 /* ID */, COMMAND, 8 /* size */);
+    CLUSTER_SUBMIT(1 /* ID */, COMMAND, 8 /* size */);
 
     CLUSTER_TRACE(
         "[ 120] 1 > submit 1 new client entry\n"
@@ -428,10 +399,7 @@ TEST(snapshot, ReceiveAppendEntriesWhileInstalling, setUp, tearDown, 0, NULL)
 
     /* Apply a new entry, server 0 won't send it to server 2 since it is
      * waiting for it to complete installing the snapshot. */
-    entry.buf.base = raft_malloc(entry.buf.len);
-    munit_assert_not_null(entry.buf.base);
-    entry.batch = entry.buf.base;
-    test_cluster_submit(&f->cluster_, 1, &entry);
+    CLUSTER_SUBMIT(1 /* ID */, COMMAND, 8 /* size */);
 
     CLUSTER_TRACE(
         "[ 200] 1 > submit 1 new client entry\n"
@@ -543,13 +511,7 @@ TEST(snapshot, InstallDuringEntriesWrite, setUp, tearDown, 0, NULL)
         "           start persisting 1 new entry (2^1)\n");
 
     /* Apply an entry, to force a snapshot to be taken. */
-    entry.term = 1;
-    entry.type = RAFT_COMMAND;
-    entry.buf.len = 8;
-    entry.buf.base = raft_malloc(entry.buf.len);
-    munit_assert_not_null(entry.buf.base);
-    entry.batch = entry.buf.base;
-    test_cluster_submit(&f->cluster_, 1, &entry);
+    CLUSTER_SUBMIT(1 /* ID */, COMMAND, 8 /* size */);
 
     CLUSTER_TRACE(
         "[  30] 1 > submit 1 new client entry\n"
@@ -575,7 +537,6 @@ TEST(snapshot, InstallDuringEntriesWrite, setUp, tearDown, 0, NULL)
 TEST(snapshot, NewTermWhileInstalling, setUp, tearDown, 0, NULL)
 {
     struct fixture *f = data;
-    struct raft_entry entry;
     unsigned id;
 
     /* Set very low threshold and trailing entries number */
@@ -613,13 +574,7 @@ TEST(snapshot, NewTermWhileInstalling, setUp, tearDown, 0, NULL)
     CLUSTER_DISCONNECT(1, 3);
 
     /* Submit a new entry, to trigger a snapshot on server 1. */
-    entry.term = 2;
-    entry.type = RAFT_COMMAND;
-    entry.buf.len = 8;
-    entry.buf.base = raft_malloc(entry.buf.len);
-    munit_assert_not_null(entry.buf.base);
-    entry.batch = entry.buf.base;
-    test_cluster_submit(&f->cluster_, 1, &entry);
+    CLUSTER_SUBMIT(1 /* ID */, COMMAND, 8 /* size */);
 
     CLUSTER_TRACE(
         "[ 120] 1 > submit 1 new client entry\n"

--- a/test/integration/test_snapshot.c
+++ b/test/integration/test_snapshot.c
@@ -23,7 +23,7 @@ static void tearDown(void *data)
 SUITE(snapshot)
 
 /* Install a snapshot on a follower that has fallen behind. */
-TEST_V1(snapshot, Install, setUp, tearDown, 0, NULL)
+TEST(snapshot, Install, setUp, tearDown, 0, NULL)
 {
     struct fixture *f = data;
     struct raft_configuration configuration;
@@ -104,7 +104,7 @@ TEST_V1(snapshot, Install, setUp, tearDown, 0, NULL)
 }
 
 /* Install snapshot times out and leader retries */
-TEST_V1(snapshot, InstallTimeout, setUp, tearDown, 0, NULL)
+TEST(snapshot, InstallTimeout, setUp, tearDown, 0, NULL)
 {
     struct fixture *f = data;
     struct raft_configuration configuration;
@@ -195,7 +195,7 @@ TEST_V1(snapshot, InstallTimeout, setUp, tearDown, 0, NULL)
 }
 
 /* Snapshots are not sent an offline nodes */
-TEST_V1(snapshot, SkipOffline, setUp, tearDown, 0, NULL)
+TEST(snapshot, SkipOffline, setUp, tearDown, 0, NULL)
 {
     struct fixture *f = data;
     struct raft_configuration configuration;
@@ -260,7 +260,7 @@ TEST_V1(snapshot, SkipOffline, setUp, tearDown, 0, NULL)
 
 /* A follower crashes while persisting a snapshot. After it resumes it sends a
  * reject response of the snapshot index. */
-TEST_V1(snapshot, AbortIfRejected, setUp, tearDown, 0, NULL)
+TEST(snapshot, AbortIfRejected, setUp, tearDown, 0, NULL)
 {
     struct fixture *f = data;
 
@@ -327,7 +327,7 @@ TEST_V1(snapshot, AbortIfRejected, setUp, tearDown, 0, NULL)
 }
 
 /* A follower receives an AppendEntries message while installing a snapshot . */
-TEST_V1(snapshot, ReceiveAppendEntriesWhileInstalling, setUp, tearDown, 0, NULL)
+TEST(snapshot, ReceiveAppendEntriesWhileInstalling, setUp, tearDown, 0, NULL)
 {
     struct fixture *f = data;
     struct raft_entry entry;
@@ -486,7 +486,7 @@ TEST_V1(snapshot, ReceiveAppendEntriesWhileInstalling, setUp, tearDown, 0, NULL)
 }
 
 /* An InstallSnapshot RPC arrives while persisting Entries */
-TEST_V1(snapshot, InstallDuringEntriesWrite, setUp, tearDown, 0, NULL)
+TEST(snapshot, InstallDuringEntriesWrite, setUp, tearDown, 0, NULL)
 {
     struct fixture *f = data;
     struct raft_configuration configuration;
@@ -572,7 +572,7 @@ TEST_V1(snapshot, InstallDuringEntriesWrite, setUp, tearDown, 0, NULL)
 }
 
 /* A new term starts while a node is installing a snapshot. */
-TEST_V1(snapshot, NewTermWhileInstalling, setUp, tearDown, 0, NULL)
+TEST(snapshot, NewTermWhileInstalling, setUp, tearDown, 0, NULL)
 {
     struct fixture *f = data;
     struct raft_entry entry;

--- a/test/integration/test_start.c
+++ b/test/integration/test_start.c
@@ -23,7 +23,7 @@ static void tearDown(void *data)
 SUITE(start)
 
 /* Start a server that has no persisted state whatsoever. */
-TEST_V1(start, NoState, setUp, tearDown, 0, NULL)
+TEST(start, NoState, setUp, tearDown, 0, NULL)
 {
     struct fixture *f = data;
     CLUSTER_START(1);
@@ -33,7 +33,7 @@ TEST_V1(start, NoState, setUp, tearDown, 0, NULL)
 }
 
 /* Start a server that has a persisted its term. */
-TEST_V1(start, PersistedTerm, setUp, tearDown, 0, NULL)
+TEST(start, PersistedTerm, setUp, tearDown, 0, NULL)
 {
     struct fixture *f = data;
     CLUSTER_SET_TERM(1 /* ID */, 1 /* term */);
@@ -43,7 +43,7 @@ TEST_V1(start, PersistedTerm, setUp, tearDown, 0, NULL)
 }
 
 /* Start a server that has a persisted its term and has a snapshot. */
-TEST_V1(start, PersistedTermAndSnapshot, setUp, tearDown, 0, NULL)
+TEST(start, PersistedTermAndSnapshot, setUp, tearDown, 0, NULL)
 {
     struct fixture *f = data;
     CLUSTER_SET_TERM(1 /* ID */, 2 /* term */);
@@ -60,7 +60,7 @@ TEST_V1(start, PersistedTermAndSnapshot, setUp, tearDown, 0, NULL)
 
 /* Start a server that has a persisted its term and has the initial bootstrap
  * log entry. */
-TEST_V1(start, PersistedTermAndEntries, setUp, tearDown, 0, NULL)
+TEST(start, PersistedTermAndEntries, setUp, tearDown, 0, NULL)
 {
     struct fixture *f = data;
     CLUSTER_SET_TERM(1 /* ID */, 1 /* term */);
@@ -72,7 +72,7 @@ TEST_V1(start, PersistedTermAndEntries, setUp, tearDown, 0, NULL)
 
 /* There are two servers. The first has a snapshot present and no other
  * entries. */
-TEST_V1(start, OneSnapshotAndNoEntries, setUp, tearDown, 0, NULL)
+TEST(start, OneSnapshotAndNoEntries, setUp, tearDown, 0, NULL)
 {
     struct fixture *f = data;
 
@@ -126,7 +126,7 @@ TEST_V1(start, OneSnapshotAndNoEntries, setUp, tearDown, 0, NULL)
 
 /* There are two servers. The first has a snapshot along with some follow-up
  * entries. */
-TEST_V1(start, OneSnapshotAndSomeFollowUpEntries, setUp, tearDown, 0, NULL)
+TEST(start, OneSnapshotAndSomeFollowUpEntries, setUp, tearDown, 0, NULL)
 {
     struct fixture *f = data;
 
@@ -177,7 +177,7 @@ TEST_V1(start, OneSnapshotAndSomeFollowUpEntries, setUp, tearDown, 0, NULL)
 
 /* There is a single voting server in the cluster, which immediately elects
  * itself when starting. */
-TEST_V1(start, SingleVotingSelfElect, setUp, tearDown, 0, NULL)
+TEST(start, SingleVotingSelfElect, setUp, tearDown, 0, NULL)
 {
     struct fixture *f = data;
     struct raft_entry entry;
@@ -211,7 +211,7 @@ TEST_V1(start, SingleVotingSelfElect, setUp, tearDown, 0, NULL)
 
 /* There are two servers in the cluster, one is voting and the other is
  * not. When started, the non-voting server does not elects itself. */
-TEST_V1(start, SingleVotingNotUs, setUp, tearDown, 0, NULL)
+TEST(start, SingleVotingNotUs, setUp, tearDown, 0, NULL)
 {
     struct fixture *f = data;
 

--- a/test/integration/test_start.c
+++ b/test/integration/test_start.c
@@ -180,7 +180,6 @@ TEST(start, OneSnapshotAndSomeFollowUpEntries, setUp, tearDown, 0, NULL)
 TEST(start, SingleVotingSelfElect, setUp, tearDown, 0, NULL)
 {
     struct fixture *f = data;
-    struct raft_entry entry;
 
     CLUSTER_SET_TERM(1 /* ID */, 1 /* term */);
     CLUSTER_ADD_ENTRY(1 /* ID */, RAFT_CHANGE, 1 /* servers */, 1 /* voters */);
@@ -192,13 +191,7 @@ TEST(start, SingleVotingSelfElect, setUp, tearDown, 0, NULL)
     munit_assert_int(raft_state(CLUSTER_RAFT(1)), ==, RAFT_LEADER);
 
     /* The server can make progress alone. */
-    entry.term = 1;
-    entry.type = RAFT_COMMAND;
-    entry.buf.len = 8;
-    entry.buf.base = raft_malloc(entry.buf.len);
-    munit_assert_not_null(entry.buf.base);
-    entry.batch = entry.buf.base;
-    test_cluster_submit(&f->cluster_, 1, &entry);
+    CLUSTER_SUBMIT(1 /* ID */, COMMAND, 8 /* size */);
 
     CLUSTER_TRACE(
         "[   0] 1 > submit 1 new client entry\n"

--- a/test/integration/test_tick.c
+++ b/test/integration/test_tick.c
@@ -31,7 +31,7 @@ SUITE(tick)
 /* If the election timeout expires, the follower is a voting server, and it
  * hasn't voted yet in this term, then become candidate and start a new
  * election. */
-TEST_V1(tick, ConvertToCandidate, setUp, tearDown, 0, NULL)
+TEST(tick, ConvertToCandidate, setUp, tearDown, 0, NULL)
 {
     struct fixture *f = data;
     struct raft *raft;
@@ -91,7 +91,7 @@ static MunitParameterEnum elapse_non_voter_params[] = {
 
 /* If the election timeout has elapsed, but we're not part of the current
  * configuration, stay follower. */
-TEST_V1(tick, NotInCurrentConfiguration, setUp, tearDown, 0, NULL)
+TEST(tick, NotInCurrentConfiguration, setUp, tearDown, 0, NULL)
 {
     struct fixture *f = data;
     CLUSTER_SET_TERM(2, 1 /* term */);
@@ -109,7 +109,7 @@ TEST_V1(tick, NotInCurrentConfiguration, setUp, tearDown, 0, NULL)
 }
 
 /* If the election timeout has elapsed, but we're not voters, stay follower. */
-TEST_V1(tick, NotVoter, setUp, tearDown, 0, elapse_non_voter_params)
+TEST(tick, NotVoter, setUp, tearDown, 0, elapse_non_voter_params)
 {
     struct fixture *f = data;
     CLUSTER_SET_TERM(2, 1 /* term */);
@@ -128,7 +128,7 @@ TEST_V1(tick, NotVoter, setUp, tearDown, 0, elapse_non_voter_params)
 
 /* If we're leader and an election timeout elapses without hearing from a
  * majority of the cluster, step down. */
-TEST_V1(tick, StepDownIfNoContact, setUp, tearDown, 0, NULL)
+TEST(tick, StepDownIfNoContact, setUp, tearDown, 0, NULL)
 {
     struct fixture *f = data;
     unsigned id;
@@ -166,7 +166,7 @@ TEST_V1(tick, StepDownIfNoContact, setUp, tearDown, 0, NULL)
 
 /* If we're candidate and the election timeout has elapsed, start a new
  * election. */
-TEST_V1(tick, NewElection, setUp, tearDown, 0, NULL)
+TEST(tick, NewElection, setUp, tearDown, 0, NULL)
 {
     struct fixture *f = data;
 

--- a/test/integration/test_transfer.c
+++ b/test/integration/test_transfer.c
@@ -29,7 +29,7 @@ static void tearDown(void *data)
 SUITE(raft_transfer)
 
 /* The follower we ask to transfer leadership to is up-to-date. */
-TEST_V1(raft_transfer, UpToDate, setUp, tearDown, 0, NULL)
+TEST(raft_transfer, UpToDate, setUp, tearDown, 0, NULL)
 {
     struct fixture *f = data;
     unsigned id;
@@ -77,7 +77,7 @@ TEST_V1(raft_transfer, UpToDate, setUp, tearDown, 0, NULL)
 }
 
 /* The follower we ask to transfer leadership to needs to catch up. */
-TEST_V1(raft_transfer, CatchUp, setUp, tearDown, 0, NULL)
+TEST(raft_transfer, CatchUp, setUp, tearDown, 0, NULL)
 {
     struct fixture *f = data;
     unsigned id;
@@ -152,7 +152,7 @@ TEST_V1(raft_transfer, CatchUp, setUp, tearDown, 0, NULL)
 
 /* The follower we ask to transfer leadership to is down and the leadership
  * transfer does not succeed. */
-TEST_V1(raft_transfer, Expire, setUp, tearDown, 0, NULL)
+TEST(raft_transfer, Expire, setUp, tearDown, 0, NULL)
 {
     struct fixture *f = data;
     unsigned id;
@@ -214,7 +214,7 @@ TEST_V1(raft_transfer, Expire, setUp, tearDown, 0, NULL)
 }
 
 /* The given ID doesn't match any server in the current configuration. */
-TEST_V1(raft_transfer, UnknownServer, setUp, tearDown, 0, NULL)
+TEST(raft_transfer, UnknownServer, setUp, tearDown, 0, NULL)
 {
     struct fixture *f = data;
     struct raft_event event;
@@ -240,7 +240,7 @@ TEST_V1(raft_transfer, UnknownServer, setUp, tearDown, 0, NULL)
 }
 
 /* Submitting a transfer request twice is an error. */
-TEST_V1(raft_transfer, Twice, setUp, tearDown, 0, NULL)
+TEST(raft_transfer, Twice, setUp, tearDown, 0, NULL)
 {
     struct fixture *f = data;
     struct raft_event event;
@@ -280,7 +280,7 @@ TEST_V1(raft_transfer, Twice, setUp, tearDown, 0, NULL)
 }
 
 /* If the given ID is zero, the target is selected automatically. */
-TEST_V1(raft_transfer, AutoSelect, setUp, tearDown, 0, NULL)
+TEST(raft_transfer, AutoSelect, setUp, tearDown, 0, NULL)
 {
     struct fixture *f = data;
     unsigned id;
@@ -321,7 +321,7 @@ TEST_V1(raft_transfer, AutoSelect, setUp, tearDown, 0, NULL)
 
 /* If the given ID is zero, the target is selected automatically. Followers that
  * are up-to-date are preferred. */
-TEST_V1(raft_transfer, AutoSelectUpToDate, setUp, tearDown, 0, NULL)
+TEST(raft_transfer, AutoSelectUpToDate, setUp, tearDown, 0, NULL)
 {
     struct fixture *f = data;
     unsigned id;
@@ -384,7 +384,7 @@ TEST_V1(raft_transfer, AutoSelectUpToDate, setUp, tearDown, 0, NULL)
 }
 
 /* It's possible to transfer leadership also when pre-vote is active */
-TEST_V1(raft_transfer, PreVote, setUp, tearDown, 0, NULL)
+TEST(raft_transfer, PreVote, setUp, tearDown, 0, NULL)
 {
     struct fixture *f = data;
     unsigned id;

--- a/test/lib/cluster.h
+++ b/test/lib/cluster.h
@@ -12,18 +12,6 @@
 #include "munit.h"
 #include "snapshot.h"
 
-#define TEST_V1(S, C, SETUP, TEAR_DOWN, OPTIONS, PARAMS)         \
-    static void *setUp__##S##_##C(const MunitParameter params[], \
-                                  void *user_data)               \
-    {                                                            \
-        return SETUP(params, user_data);                         \
-    }                                                            \
-    static void tearDown__##S##_##C(void *data)                  \
-    {                                                            \
-        TEAR_DOWN(data);                                         \
-    }                                                            \
-    TEST(S, C, setUp__##S##_##C, tearDown__##S##_##C, OPTIONS, PARAMS)
-
 #define FIXTURE_CLUSTER \
     FIXTURE_HEAP;       \
     struct test_cluster cluster_

--- a/test/lib/cluster.h
+++ b/test/lib/cluster.h
@@ -23,38 +23,31 @@
 /* Start the server with the given ID, using the state persisted on its disk. */
 #define CLUSTER_START(ID) test_cluster_start(&f->cluster_, ID)
 
+/* Stop the server with the given ID. */
+#define CLUSTER_STOP(ID) test_cluster_stop(&f->cluster_, ID);
+
+/* Step the cluster until the all expected output is consumed. Fail the test if
+ * a mismatch is found. */
 #define CLUSTER_TRACE(EXPECTED)                        \
     if (!test_cluster_trace(&f->cluster_, EXPECTED)) { \
         munit_error("trace does not match");           \
     }
 
+/* Step the cluster until the given amount of milliseconds has elapsed. */
 #define CLUSTER_ELAPSE(MSECS) test_cluster_elapse(&f->cluster_, MSECS)
 
-#define CLUSTER_RAFT(ID) test_cluster_raft(&f->cluster_, ID)
-
-/* Stop the server with the given ID. */
-#define CLUSTER_STOP(ID) test_cluster_stop(&f->cluster_, ID);
-
+/* Disconnect the server with ID1 with the one with ID2. */
 #define CLUSTER_DISCONNECT(ID1, ID2) \
     test_cluster_disconnect(&f->cluster_, ID1, ID2)
 
-/* Reconnect A to B. */
+/* Reconnect two servers. */
 #define CLUSTER_RECONNECT(ID1, ID2) \
     test_cluster_reconnect(&f->cluster_, ID1, ID2)
 
-/* Set the network latency of outgoing messages of server I. */
-#define CLUSTER_SET_NETWORK_LATENCY(ID, MSECS) \
-    test_cluster_set_network_latency(&f->cluster_, ID, MSECS)
-
-/* Set the disk I/O latency of server I. */
-#define CLUSTER_SET_DISK_LATENCY(ID, MSECS) \
-    test_cluster_set_disk_latency(&f->cluster_, ID, MSECS)
-
+/* Set the persisted vote of the server with the given ID. Must me called before
+ * starting the server. */
 #define CLUSTER_SET_VOTE(ID, VOTE) \
     test_cluster_set_vote(&f->cluster_, ID, VOTE);
-
-#define CLUSTER_SET_ELECTION_TIMEOUT(ID, TIMEOUT, DELTA) \
-    test_cluster_set_election_timeout(&f->cluster_, ID, TIMEOUT, DELTA)
 
 /* Set the persisted term of the server with the given ID. Must me called before
  * starting the server. */
@@ -144,6 +137,20 @@
  * be called before starting the cluster. */
 #define CLUSTER_ADD_ENTRY_RAW(ID, ENTRY) \
     test_cluster_add_entry(&f->cluster_, ID, ENTRY)
+
+/* Return the struct raft object with the given ID. */
+#define CLUSTER_RAFT(ID) test_cluster_raft(&f->cluster_, ID)
+
+/* Set the network latency of outgoing messages of server I. */
+#define CLUSTER_SET_NETWORK_LATENCY(ID, MSECS) \
+    test_cluster_set_network_latency(&f->cluster_, ID, MSECS)
+
+/* Set the disk I/O latency of server I. */
+#define CLUSTER_SET_DISK_LATENCY(ID, MSECS) \
+    test_cluster_set_disk_latency(&f->cluster_, ID, MSECS)
+
+#define CLUSTER_SET_ELECTION_TIMEOUT(ID, TIMEOUT, DELTA) \
+    test_cluster_set_election_timeout(&f->cluster_, ID, TIMEOUT, DELTA)
 
 /* Test snapshot that is just persisted in-memory. */
 struct test_snapshot

--- a/test/lib/cluster.h
+++ b/test/lib/cluster.h
@@ -152,10 +152,10 @@
         test_cluster_add_entry(&f->cluster_, ID, &_entry); \
     } while (0);
 
-/* Add an entry to the ones persisted on the I'th server. This must be called
- * before starting the cluster. */
-#define CLUSTER_ADD_ENTRY_RAW(I, ENTRY) \
-    test_cluster_add_entry(&f->cluster_, I, ENTRY)
+/* Add an entry to the ones persisted on the server with the given ID. This must
+ * be called before starting the cluster. */
+#define CLUSTER_ADD_ENTRY_RAW(ID, ENTRY) \
+    test_cluster_add_entry(&f->cluster_, ID, ENTRY)
 
 /* Test snapshot that is just persisted in-memory. */
 struct test_snapshot

--- a/test/lib/macros.h
+++ b/test/lib/macros.h
@@ -9,5 +9,6 @@
 #define GET_3RD_ARG(arg1, arg2, arg3, ...) arg3
 #define GET_4TH_ARG(arg1, arg2, arg3, arg4, ...) arg4
 #define GET_5TH_ARG(arg1, arg2, arg3, arg4, arg5, ...) arg5
+#define GET_6TH_ARG(arg1, arg2, arg3, arg4, arg5, arg6, ...) arg6
 
 #endif /* TEST_MACROS_H_ */


### PR DESCRIPTION
This is a convenience for saving some boilerplate in test code.