### PR TITLE
progress: Add helpers for check online/recency status

### DIFF
--- a/src/progress.c
+++ b/src/progress.c
@@ -235,11 +235,6 @@ raft_time progressGetLastSend(const struct raft *r, const unsigned i)
     return last_send;
 }
 
-raft_time progressGetLastRecv(const struct raft *r, const unsigned i)
-{
-    return r->leader_state.progress[i].last_recv;
-}
-
 void progressToSnapshot(struct raft *r, unsigned i)
 {
     struct raft_progress *p = &r->leader_state.progress[i];

--- a/src/progress.c
+++ b/src/progress.c
@@ -108,7 +108,7 @@ bool progressIsUpToDate(struct raft *r, unsigned i)
 
 bool progressIsOnline(struct raft *r, unsigned i)
 {
-    raft_time last_recv = progressGetLastRecv(r, i);
+    raft_time last_recv = r->leader_state.progress[i].last_recv;
 
     if (last_recv == ULLONG_MAX) {
         return false;
@@ -116,6 +116,17 @@ bool progressIsOnline(struct raft *r, unsigned i)
 
     assert(r->now >= last_recv);
     return r->now - last_recv < r->election_timeout;
+}
+
+bool progressHasContactedRecently(struct raft *r, unsigned i)
+{
+    raft_time last_recv = r->leader_state.progress[i].last_recv;
+
+    if (last_recv != ULLONG_MAX && last_recv >= r->election_timer_start) {
+        return true;
+    }
+
+    return false;
 }
 
 bool progressShouldReplicate(struct raft *r, unsigned i)

--- a/src/progress.c
+++ b/src/progress.c
@@ -106,6 +106,18 @@ bool progressIsUpToDate(struct raft *r, unsigned i)
     return p->next_index == last_index + 1;
 }
 
+bool progressIsOnline(struct raft *r, unsigned i)
+{
+    raft_time last_recv = progressGetLastRecv(r, i);
+
+    if (last_recv == ULLONG_MAX) {
+        return false;
+    }
+
+    assert(r->now >= last_recv);
+    return r->now - last_recv < r->election_timeout;
+}
+
 bool progressShouldReplicate(struct raft *r, unsigned i)
 {
     struct raft_progress *p = &r->leader_state.progress[i];

--- a/src/progress.h
+++ b/src/progress.h
@@ -105,9 +105,6 @@ void progressResetRecentRecv(struct raft *r);
  * timestamp if more recent. */
 raft_time progressGetLastSend(const struct raft *r, unsigned i);
 
-/* Return the value of the last_recv flag. */
-raft_time progressGetLastRecv(const struct raft *r, unsigned i);
-
 /* Convert to the i'th server to snapshot mode. */
 void progressToSnapshot(struct raft *r, unsigned i);
 

--- a/src/progress.h
+++ b/src/progress.h
@@ -66,6 +66,12 @@ bool progressIsUpToDate(struct raft *r, unsigned i);
  * timeout. */
 bool progressIsOnline(struct raft *r, unsigned i);
 
+/* Whether the i'th server in the configuration has contacted us recently.
+ *
+ * A server has contacted us recently if we received a message from it within
+ * the last election timer reset. */
+bool progressHasContactedRecently(struct raft *r, unsigned i);
+
 /* Whether a new AppendEntries or InstallSnapshot message should be sent to the
  * i'th server at this time.
  *

--- a/src/progress.h
+++ b/src/progress.h
@@ -56,9 +56,15 @@ int progressBuildArray(struct raft *r);
 int progressRebuildArray(struct raft *r,
                          const struct raft_configuration *configuration);
 
-/* Whether the log of the i'th server in the configuration up-to-date with
+/* Whether the log of the i'th server in the configuration is up-to-date with
  * ours. */
 bool progressIsUpToDate(struct raft *r, unsigned i);
+
+/* Whether the i'th server in the configuration is online or not.
+ *
+ * A server is online if we received a message from it within the last election
+ * timeout. */
+bool progressIsOnline(struct raft *r, unsigned i);
 
 /* Whether a new AppendEntries or InstallSnapshot message should be sent to the
  * i'th server at this time.

--- a/src/replication.c
+++ b/src/replication.c
@@ -168,20 +168,11 @@ int replicationProgress(struct raft *r, unsigned i)
     raft_index prev_index;
     raft_term prev_term;
     int max = MAX_APPEND_ENTRIES;
-    raft_time last_recv = progressGetLastRecv(r, i);
-    bool is_online;
     bool needs_snapshot = false;
 
     assert(r->state == RAFT_LEADER);
     assert(server->id != r->id);
     assert(next_index >= 1);
-
-    if (last_recv == ULLONG_MAX) {
-        is_online = false;
-    } else {
-        assert(r->now >= last_recv);
-        is_online = r->now - last_recv < r->election_timeout;
-    }
 
     /* From Section 3.5:
      *
@@ -232,7 +223,7 @@ int replicationProgress(struct raft *r, unsigned i)
 
         assert(snapshot_index > 0);
 
-        if (!progress_state_is_snapshot && is_online) {
+        if (!progress_state_is_snapshot && progressIsOnline(r, i)) {
             return sendSnapshot(r, i);
         }
 

--- a/src/tick.c
+++ b/src/tick.c
@@ -111,14 +111,7 @@ static bool checkContactQuorum(struct raft *r)
 
     for (i = 0; i < r->configuration.n; i++) {
         struct raft_server *server = &r->configuration.servers[i];
-        raft_time last_recv = progressGetLastRecv(r, i);
-        bool is_recent = false;
-
-        /* A contact is recent if it happened after the last election timer
-         * reset. */
-        if (last_recv != ULLONG_MAX && last_recv >= r->election_timer_start) {
-            is_recent = true;
-        }
+        bool is_recent = progressHasContactedRecently(r, i);
 
         if ((server->role == RAFT_VOTER && is_recent) || server->id == r->id) {
             contacts++;


### PR DESCRIPTION
Simplify call sites by moving some logic to `progress.c`.