### PR TITLE
replication: Limit maximum the number of total entries in-flight

### DIFF
--- a/include/raft.h.in
+++ b/include/raft.h.in
@@ -835,8 +835,10 @@ struct raft
      * after a server restart.
      */
     raft_index commit_index; /* Highest log entry known to be committed */
+#if !defined(RAFT__LEGACY_no)
     raft_index last_applied; /* Highest log entry applied to the FSM */
-    raft_index last_stored;  /* Highest log entry persisted on disk */
+#endif
+    raft_index last_stored; /* Highest log entry persisted on disk */
 
     /*
      * Current server state of this raft instance, along with a union defining

--- a/include/raft.h.in
+++ b/include/raft.h.in
@@ -630,7 +630,7 @@ struct raft; /* Forward declaration. */
         unsigned random; /* Pseudo-random number generator state */        \
         struct raft_message *messages; /* Pre-allocated message queue */   \
         unsigned n_messages_cap;       /* Capacity of the message queue */ \
-        unsigned unused1;              /* XXX: For backward ABI compat */  \
+        unsigned max_inflight_entries; /* Pending entries limit */         \
         /* Index of the last snapshot that was taken */                    \
         raft_index configuration_last_snapshot_index;                      \
         RAFT__EXTENSIONS_LEGACY                                            \
@@ -1100,6 +1100,16 @@ RAFT_API void raft_set_max_catch_up_rounds(struct raft *r, unsigned n);
  */
 RAFT_API void raft_set_max_catch_up_round_duration(struct raft *r,
                                                    unsigned msecs);
+
+/**
+ * Set the maximum number of in-flight append messages that will be
+ * optimistically sent to peers without waiting for acknowledgment. The engine
+ * will stop sending more messages if this limit is reached. The default is 32.
+ *
+ * This limit also applies to entries being persisted locally and that haven't
+ * been acknowledged yet.
+ */
+RAFT_API void raft_set_max_inflight_entries(struct raft *r, unsigned n);
 
 /**
  * Return a human-readable description of the last error occurred.

--- a/src/legacy.c
+++ b/src/legacy.c
@@ -1807,4 +1807,9 @@ out:
     return 0;
 }
 
+raft_index raft_last_applied(struct raft *r)
+{
+    return r->last_applied;
+}
+
 #undef tracef

--- a/src/raft.c
+++ b/src/raft.c
@@ -39,6 +39,8 @@
 #define DEFAULT_MAX_CATCH_UP_ROUNDS 10
 #define DEFAULT_MAX_CATCH_UP_ROUND_DURATION (5 * 1000)
 
+#define DEFAULT_MAX_INFLIGHT_ENTRIES 32
+
 #define infof(...) Infof(r->tracer, "> " __VA_ARGS__)
 
 int raft_version_number(void)
@@ -112,6 +114,7 @@ int raft_init(struct raft *r,
     r->now = 0;
     r->messages = NULL;
     r->n_messages_cap = 0;
+    r->max_inflight_entries = DEFAULT_MAX_INFLIGHT_ENTRIES;
     r->update = NULL;
 #if defined(RAFT__LEGACY_no)
     (void)io;
@@ -692,6 +695,11 @@ void raft_set_max_catch_up_rounds(struct raft *r, unsigned n)
 void raft_set_max_catch_up_round_duration(struct raft *r, unsigned msecs)
 {
     r->max_catch_up_round_duration = msecs;
+}
+
+void raft_set_max_inflight_entries(struct raft *r, unsigned n)
+{
+    r->max_inflight_entries = n;
 }
 
 void raft_set_pre_vote(struct raft *r, bool enabled)

--- a/src/state.c
+++ b/src/state.c
@@ -38,11 +38,6 @@ raft_index raft_last_index(struct raft *r)
     return TrailLastIndex(&r->trail);
 }
 
-raft_index raft_last_applied(struct raft *r)
-{
-    return r->last_applied;
-}
-
 int raft_role(struct raft *r)
 {
     const struct raft_server *local =


### PR DESCRIPTION
Limit the number of total entries that might be in-flight, i.e. that have been sent to a follower, but haven't yet been acknowledged.

Add `raft_set_max_inflight_entries()` to make that limit configurable.