### PR TITLE
replication: Set a saturated status flag when entries are lagging

### DIFF
--- a/include/raft.h.in
+++ b/include/raft.h.in
@@ -344,6 +344,7 @@ struct raft_append_entries_result
     raft_index rejected;       /* If non-zero, the index that was rejected. */
     raft_index last_log_index; /* Receiver's last log entry index, as hint. */
     unsigned features;         /* Feature flags (since version 1). */
+    unsigned flags;            /* Status flags (since version 1). */
 };
 #define RAFT_APPEND_ENTRIES_RESULT_VERSION 1
 

--- a/include/raft.h.in
+++ b/include/raft.h.in
@@ -1107,8 +1107,9 @@ RAFT_API void raft_set_max_catch_up_round_duration(struct raft *r,
  * optimistically sent to peers without waiting for acknowledgment. The engine
  * will stop sending more messages if this limit is reached. The default is 32.
  *
- * This limit also applies to entries being persisted locally and that haven't
- * been acknowledged yet.
+ * This limit also applies to entries being persisted locally. A follower will
+ * stop accepting new entries if it reaches this number of not-yet-written
+ * entries.
  */
 RAFT_API void raft_set_max_inflight_entries(struct raft *r, unsigned n);
 

--- a/src/progress.c
+++ b/src/progress.c
@@ -30,6 +30,7 @@ static void initProgress(struct raft_progress *p, raft_index last_index)
     p->state = PROGRESS__PROBE;
     p->catch_up = RAFT_CATCH_UP_NONE;
     p->features = 0;
+    p->flags = 0;
 }
 
 int progressBuildArray(struct raft *r)
@@ -221,6 +222,16 @@ void progressSetFeatures(struct raft *r, const unsigned i, unsigned features)
 unsigned progressGetFeatures(struct raft *r, const unsigned i)
 {
     return r->leader_state.progress[i].features;
+}
+
+void progressSetFlags(struct raft *r, const unsigned i, unsigned flags)
+{
+    r->leader_state.progress[i].flags = flags;
+}
+
+unsigned progressGetFlags(struct raft *r, const unsigned i)
+{
+    return r->leader_state.progress[i].flags;
 }
 
 raft_time progressGetLastSend(const struct raft *r, const unsigned i)

--- a/src/progress.h
+++ b/src/progress.h
@@ -24,6 +24,7 @@ struct raft_progress
     raft_time last_send;     /* Timestamp of last AppendEntries RPC. */
     raft_time last_recv;     /* Timestamp of last AppendEntries result. */
     unsigned features;       /* What the server is capable of. */
+    unsigned flags;          /* Status flags */
     struct
     {
         raft_index index;    /* Last index of most recent snapshot sent. */
@@ -148,11 +149,17 @@ bool progressMaybeDecrement(struct raft *r,
 /* Return true if match_index is equal or higher than the snapshot_index. */
 bool progressSnapshotDone(struct raft *r, unsigned i);
 
-/* Sets the feature flags of a node. */
+/* Sets the features of a node. */
 void progressSetFeatures(struct raft *r, unsigned i, unsigned features);
 
-/* Gets the feature flags of a node. */
+/* Gets the features of a node. */
 unsigned progressGetFeatures(struct raft *r, unsigned i);
+
+/* Sets the status flags of a node. */
+void progressSetFlags(struct raft *r, unsigned i, unsigned flags);
+
+/* Gets the status flags of a node. */
+unsigned progressGetFlags(struct raft *r, unsigned i);
 
 /* Start catching up a server. */
 void progressCatchUpStart(struct raft *r, unsigned i);

--- a/src/progress.h
+++ b/src/progress.h
@@ -12,6 +12,9 @@ enum {
     PROGRESS__SNAPSHOT   /* Sending a snapshot */
 };
 
+/* Server status flags. */
+#define PROGRESS__SATURATED 1 << 0 /* Too many unpersisted entries */
+
 /**
  * Used by leaders to keep track of replication progress for each server.
  */

--- a/src/recv_append_entries.c
+++ b/src/recv_append_entries.c
@@ -5,6 +5,7 @@
 #include "entry.h"
 #include "heap.h"
 #include "message.h"
+#include "progress.h"
 #include "recv.h"
 #include "replication.h"
 #include "tracing.h"
@@ -147,7 +148,18 @@ int recvAppendEntries(struct raft *r,
          * We use a stored index instead of an in-memory one because the leader
          * will use it to update our match index and to check quorum. */
         result->last_log_index = args->prev_log_index + args->n_entries;
-        assert(last_index >= result->last_log_index);
+
+        /* If we are saturated the stored index must be lagging behind our last
+         * index.
+         *
+         * Otherwise, our in-memory log must now contain all entries in this
+         * request. */
+        if (result->flags & PROGRESS__SATURATED) {
+            assert(r->last_stored < last_index);
+        } else {
+            assert(last_index >= result->last_log_index);
+        }
+
         if (result->last_log_index > r->last_stored) {
             result->last_log_index = r->last_stored;
         }

--- a/src/recv_append_entries.c
+++ b/src/recv_append_entries.c
@@ -34,6 +34,7 @@ int recvAppendEntries(struct raft *r,
     result->last_log_index = TrailLastIndex(&r->trail);
     result->version = RAFT_APPEND_ENTRIES_RESULT_VERSION;
     result->features = 0;
+    result->flags = 0;
 
     recvEnsureMatchingTerms(r, args->term, &match);
 

--- a/src/recv_append_entries.c
+++ b/src/recv_append_entries.c
@@ -114,7 +114,7 @@ int recvAppendEntries(struct raft *r,
         return 0;
     }
 
-    rv = replicationAppend(r, args, &result->rejected, &async);
+    rv = replicationAppend(r, args, &result->flags, &result->rejected, &async);
     if (rv != 0 && rv != RAFT_BUSY) {
         goto err;
     }

--- a/src/recv_install_snapshot.c
+++ b/src/recv_install_snapshot.c
@@ -27,6 +27,7 @@ int recvInstallSnapshot(struct raft *r,
     result->last_log_index = TrailLastIndex(&r->trail);
     result->version = RAFT_APPEND_ENTRIES_RESULT_VERSION;
     result->features = 0;
+    result->flags = 0;
 
     recvEnsureMatchingTerms(r, args->term, &match);
 

--- a/src/replication.c
+++ b/src/replication.c
@@ -454,6 +454,7 @@ int replicationUpdate(struct raft *r,
     progressUpdateLastRecv(r, i);
 
     progressSetFeatures(r, i, result->features);
+    progressSetFlags(r, i, result->flags);
 
     /* If the RPC failed because of a log mismatch, retry.
      *
@@ -776,6 +777,7 @@ static int deleteConflictingEntries(struct raft *r,
 
 int replicationAppend(struct raft *r,
                       const struct raft_append_entries *args,
+                      unsigned *flags,
                       raft_index *rejected,
                       bool *async)
 {
@@ -795,6 +797,7 @@ int replicationAppend(struct raft *r,
 
     assert(r->state == RAFT_FOLLOWER);
 
+    *flags = 0;
     *rejected = args->prev_log_index;
     *async = false;
 

--- a/src/replication.h
+++ b/src/replication.h
@@ -71,6 +71,7 @@ int replicationUpdate(struct raft *r,
  * It must be called only by followers. */
 int replicationAppend(struct raft *r,
                       const struct raft_append_entries *args,
+                      unsigned *flags,
                       raft_index *rejected,
                       bool *async);
 

--- a/src/uv_encoding.c
+++ b/src/uv_encoding.c
@@ -37,7 +37,8 @@ static size_t sizeofRequestVoteResultV1(void)
 static size_t sizeofRequestVoteResult(void)
 {
     return sizeofRequestVoteResultV1() + /* Size of older version 1 message */
-           sizeof(uint64_t) /* Flags. */;
+           sizeof(uint32_t) +            /* Features */
+           sizeof(uint32_t);             /* Flags */
 }
 
 static size_t sizeofAppendEntries(const struct raft_append_entries *p)
@@ -151,7 +152,7 @@ static void encodeAppendEntriesResult(
     bytePut64(&cursor, p->rejected);
     bytePut64(&cursor, p->last_log_index);
     bytePut32(&cursor, p->features);
-    bytePut32(&cursor, 0 /* Unused */);
+    bytePut32(&cursor, p->flags);
 }
 
 static void encodeInstallSnapshot(const struct raft_install_snapshot *p,
@@ -454,6 +455,7 @@ static void decodeAppendEntriesResult(const uv_buf_t *buf,
     if (buf->len > sizeofAppendEntriesResultV0()) {
         p->version = 1;
         p->features = byteGet32(&cursor);
+        p->flags = byteGet32(&cursor);
     }
 }
 

--- a/test/integration/test_replication.c
+++ b/test/integration/test_replication.c
@@ -2095,3 +2095,85 @@ TEST(replication, LastStoredAheadOfPrevLogIndex, setUp, tearDown, 0, NULL)
 
     return MUNIT_OK;
 }
+
+/* A follower stops accepting new entries because it has too many unpersisted
+ * entries. */
+TEST(replication, SaturatedByUnpersistedEntries, setUp, tearDown, 0, NULL)
+{
+    struct fixture *f = data;
+    unsigned id;
+
+    /* Bootstrap and start a cluster with 2 voters. */
+    for (id = 1; id <= 2; id++) {
+        CLUSTER_SET_TERM(id, 1 /* term */);
+        CLUSTER_ADD_ENTRY(id, RAFT_CHANGE, 2 /* servers */, 2 /* voters */);
+        CLUSTER_START(id);
+    }
+
+    /* Server 2 takes a long time to persist entries, and will stop accepting
+     * new entries after there is 1 unpersisted entry. */
+    CLUSTER_SET_DISK_LATENCY(2 /* ID */, 70);
+    raft_set_max_inflight_entries(CLUSTER_RAFT(2), 1);
+
+    /* Server 1 becomes leader. */
+    CLUSTER_TRACE(
+        "[   0] 1 > term 1, 1 entry (1^1)\n"
+        "[   0] 2 > term 1, 1 entry (1^1)\n"
+        "[ 100] 1 > timeout as follower\n"
+        "           convert to candidate, start election for term 2\n"
+        "[ 110] 2 > recv request vote from server 1\n"
+        "           remote term is higher (2 vs 1) -> bump term\n"
+        "           remote log is equal (1^1) -> grant vote\n"
+        "[ 120] 1 > recv request vote result from server 2\n"
+        "           quorum reached with 2 votes out of 2 -> convert to leader\n"
+        "           probe server 2 sending a heartbeat (no entries)\n");
+
+    /* Submit a new entry. Server 2 receives it and starts persisting it. */
+    CLUSTER_SUBMIT(1 /* ID */, COMMAND, 8 /* size */);
+    CLUSTER_TRACE(
+        "[ 120] 1 > submit 1 new client entry\n"
+        "           replicate 1 new command entry (2^2)\n"
+        "[ 130] 1 > persisted 1 entry (2^2)\n"
+        "           next uncommitted entry (2^2) has 1 vote out of 2\n"
+        "[ 130] 2 > recv append entries from server 1\n"
+        "           no new entries to persist\n"
+        "[ 140] 1 > recv append entries result from server 2\n"
+        "           pipeline server 2 sending 1 entry (2^2)\n"
+        "[ 150] 2 > recv append entries from server 1\n"
+        "           start persisting 1 new entry (2^2)\n");
+
+    /* Submit a further entry. Server 2 receives it, but it ignores it. */
+    CLUSTER_SUBMIT(1 /* ID */, COMMAND, 8 /* size */);
+    CLUSTER_TRACE(
+        "[ 150] 1 > submit 1 new client entry\n"
+        "           replicate 1 new command entry (3^2)\n"
+        "           pipeline server 2 sending 1 entry (3^2)\n"
+        "[ 160] 1 > persisted 1 entry (3^2)\n"
+        "           next uncommitted entry (2^2) has 1 vote out of 2\n"
+        "[ 160] 2 > recv append entries from server 1\n"
+        "           already persisting 1 entries -> ignore 1 new entries\n");
+
+    /* The leader notices the saturated flag and reverts server 2 to probe. */
+    CLUSTER_TRACE(
+        "[ 170] 1 > recv append entries result from server 2\n"
+        "           follower is saturated\n"
+        "[ 200] 1 > timeout as leader\n"
+        "           probe server 2 sending a heartbeat (no entries)\n");
+
+    /* Eventually server 2 completes persisting the first entry and accepts the
+     * second one. */
+    CLUSTER_TRACE(
+        "[ 210] 2 > recv append entries from server 1\n"
+        "           already persisting 1 entries -> ignore 0 new entries\n"
+        "[ 220] 2 > persisted 1 entry (2^2)\n"
+        "           send success result to 1\n"
+        "[ 220] 1 > recv append entries result from server 2\n"
+        "           follower is saturated\n"
+        "[ 230] 1 > recv append entries result from server 2\n"
+        "           pipeline server 2 sending 1 entry (3^2)\n"
+        "           commit 1 new entry (2^2)\n"
+        "[ 240] 2 > recv append entries from server 1\n"
+        "           start persisting 1 new entry (3^2)\n");
+
+    return MUNIT_OK;
+}


### PR DESCRIPTION
If a follower is not persisting entries fast enough (e.g. because the disk is full), it will now stop accepting new entries, and will set a status flag for informing the leader of this.

In turn, the leader will stop sending new entries until the follower clears the flag.
