### PR TITLE
v1: Drop status field from RAFT_PERSISTED_ENTRIES event

### DIFF
--- a/include/raft.h.in
+++ b/include/raft.h.in
@@ -485,7 +485,6 @@ struct raft_event
             raft_index index;
             struct raft_entry *batch;
             unsigned n;
-            int status;
         } persisted_entries;
         struct
         {

--- a/src/legacy.c
+++ b/src/legacy.c
@@ -916,53 +916,6 @@ static int legacyApply(struct raft *r,
     return rv;
 }
 
-static void legacyPersistedEntriesFailure(struct raft *r,
-                                          struct raft_event *event)
-{
-    raft_index index = event->persisted_entries.index;
-    unsigned n = event->persisted_entries.n;
-    int status = event->persisted_entries.status;
-
-    for (unsigned i = 0; i < n; i++) {
-        struct request *req = legacyGetRequest(r, index + i, -1);
-        if (!req) {
-            tracef("no request found at index %llu", index + i);
-            continue;
-        }
-        switch (req->type) {
-            case RAFT_COMMAND: {
-                struct raft_apply *apply = (struct raft_apply *)req;
-                if (apply->cb) {
-                    apply->status = status;
-                    apply->result = NULL;
-                    QUEUE_PUSH(&r->legacy.requests, &apply->queue);
-                }
-                break;
-            }
-            case RAFT_BARRIER: {
-                struct raft_barrier *barrier = (struct raft_barrier *)req;
-                if (barrier->cb) {
-                    barrier->status = status;
-                    QUEUE_PUSH(&r->legacy.requests, &barrier->queue);
-                }
-                break;
-            }
-            case RAFT_CHANGE: {
-                struct raft_change *change = (struct raft_change *)req;
-                if (change->cb) {
-                    change->status = status;
-                    QUEUE_PUSH(&r->legacy.requests, &change->queue);
-                }
-                break;
-            }
-            default:
-                tracef("unknown request type, shutdown.");
-                assert(false);
-                break;
-        }
-    }
-}
-
 void LegacyLeadershipTransferClose(struct raft *r)
 {
     struct raft_transfer *req = r->transfer;
@@ -980,18 +933,11 @@ void LegacyLeadershipTransferClose(struct raft *r)
     }
 }
 
-static void legacyHandleStateUpdate(struct raft *r, struct raft_event *event)
+static void legacyHandleStateUpdate(struct raft *r)
 {
     assert(r->legacy.prev_state != r->state);
 
     if (r->legacy.prev_state == RAFT_LEADER) {
-        /* If we're stepping down because of disk write failure, fail
-         * requests using the same status code as the write failure.*/
-        if (event->type == RAFT_PERSISTED_ENTRIES &&
-            event->persisted_entries.status != 0) {
-            legacyPersistedEntriesFailure(r, event);
-        }
-
         LegacyFailPendingRequests(r);
         assert(QUEUE_IS_EMPTY(&r->legacy.pending));
     }
@@ -1090,7 +1036,7 @@ static int legacyHandleEvent(struct raft *r,
     }
 
     if (update.flags & RAFT_UPDATE_STATE) {
-        legacyHandleStateUpdate(r, event);
+        legacyHandleStateUpdate(r);
     }
 
     /* Check whether a raft_change request has been completed. */

--- a/src/legacy.c
+++ b/src/legacy.c
@@ -143,7 +143,6 @@ static void legacyPersistEntriesCb(struct raft_io_append *append, int status)
     event.persisted_entries.index = req->index;
     event.persisted_entries.batch = req->entries;
     event.persisted_entries.n = req->n;
-    event.persisted_entries.status = 0;
 
     LegacyForwardToRaftIo(r, &event);
 

--- a/src/raft.c
+++ b/src/raft.c
@@ -388,8 +388,7 @@ static int stepStart(struct raft *r,
 static int stepPersistedEntries(struct raft *r,
                                 raft_index index,
                                 struct raft_entry *entries,
-                                unsigned n,
-                                int status)
+                                unsigned n)
 {
     raft_index last_stored = r->last_stored + n;
     raft_index last_index = TrailLastIndex(&r->trail);
@@ -406,7 +405,7 @@ static int stepPersistedEntries(struct raft *r,
               entries[0].term, index + n - 1, entries[n - 1].term);
     }
 
-    rv = replicationPersistEntriesDone(r, index, entries, n, status);
+    rv = replicationPersistEntriesDone(r, index, entries, n);
 
     return rv;
 }
@@ -510,8 +509,7 @@ int raft_step(struct raft *r,
         case RAFT_PERSISTED_ENTRIES:
             rv = stepPersistedEntries(r, event->persisted_entries.index,
                                       event->persisted_entries.batch,
-                                      event->persisted_entries.n,
-                                      event->persisted_entries.status);
+                                      event->persisted_entries.n);
             break;
         case RAFT_PERSISTED_SNAPSHOT:
             rv = stepPersistedSnapshot(r, &event->persisted_snapshot.metadata,

--- a/src/replication.h
+++ b/src/replication.h
@@ -86,8 +86,7 @@ bool replicationInstallSnapshotBusy(struct raft *r);
 int replicationPersistEntriesDone(struct raft *r,
                                   raft_index index,
                                   struct raft_entry *entries,
-                                  unsigned n,
-                                  int status);
+                                  unsigned n);
 
 /* Called when handling RAFT_PERSISTED_SNAPSHOT event. */
 int replicationPersistSnapshotDone(struct raft *r,

--- a/test/lib/cluster.c
+++ b/test/lib/cluster.c
@@ -411,13 +411,8 @@ static void serverCancelEntries(struct test_server *s, struct step *step)
 {
     struct raft_event *event = &step->event;
     unsigned n = event->persisted_entries.n;
-    int rv;
 
-    event->time = s->cluster->time;
-    event->persisted_entries.status = RAFT_CANCELED;
-
-    rv = serverStep(s, &step->event);
-    munit_assert_int(rv, ==, 0);
+    (void)s;
 
     if (n > 0) {
         raft_free(event->persisted_entries.batch[0].batch);


### PR DESCRIPTION
It is now unnecessary.