### PR TITLE
replication: Update commit index eagerly on followers

### DIFF
--- a/src/membership.c
+++ b/src/membership.c
@@ -136,7 +136,8 @@ int membershipUncommittedChange(struct raft *r,
 
     rv = configurationDecode(&entry->buf, &configuration);
     if (rv != 0) {
-        goto err;
+        assert(rv == RAFT_NOMEM || rv == RAFT_MALFORMED);
+        return rv;
     }
 
     raft_configuration_close(&r->configuration);
@@ -145,10 +146,6 @@ int membershipUncommittedChange(struct raft *r,
     r->configuration_uncommitted_index = index;
 
     return 0;
-
-err:
-    assert(rv != 0);
-    return rv;
 }
 
 int membershipRollback(struct raft *r)

--- a/src/membership.h
+++ b/src/membership.h
@@ -40,11 +40,21 @@ int membershipFetchLastCommittedConfiguration(struct raft *r,
 bool membershipUpdateCatchUpRound(struct raft *r);
 
 /* Update the local configuration replacing it with the content of the given
- * RAFT_CHANGE entry, which has just been received in as part of an
- * AppendEntries RPC request. The uncommitted configuration index will be
- * updated accordingly.
+ * RAFT_CHANGE entry, which has just been received in as part of a RAFT_SUBMIT
+ * event on a leader or a RAFT_RECEIVE event of an AppendEntries message on a
+ * follower. The uncommitted configuration index will be updated accordingly.
  *
- * It must be called only by followers. */
+ * It must be called only by followers or leaders.
+ *
+ * Errors:
+ *
+ * RAFT_NOMEM
+ *     A new raft_configuration object to hold the decoded configuration could
+ *     not be allocated.
+ *
+ * RAFT_MALFORMED
+ *     The entry data does not contain a valid encoded configuration.
+ */
 int membershipUncommittedChange(struct raft *r,
                                 const raft_index index,
                                 const struct raft_entry *entry);

--- a/src/replication.c
+++ b/src/replication.c
@@ -807,11 +807,9 @@ int replicationAppend(struct raft *r,
      *   commitIndex, set commitIndex = min(leaderCommit, index of last new
      *   entry).
      */
-    if (args->leader_commit > r->commit_index &&
-        r->last_stored >= r->commit_index) {
-        raft_index last_index =
-            min(r->last_stored, args->prev_log_index + args->n_entries);
-        r->commit_index = min(args->leader_commit, last_index);
+    if (args->leader_commit > r->commit_index) {
+        raft_index last_new_entry = args->prev_log_index + args->n_entries;
+        r->commit_index = min(args->leader_commit, last_new_entry);
         r->update->flags |= RAFT_UPDATE_COMMIT_INDEX;
     }
 


### PR DESCRIPTION
We don't need to wait for entries to be persisted.