### PR TITLE
Use of uninitialized memory in outgoing append entries result frames

### DIFF
--- a/src/recv_append_entries.c
+++ b/src/recv_append_entries.c
@@ -34,9 +34,6 @@ int recvAppendEntries(struct raft *r,
     result->version = MESSAGE__APPEND_ENTRIES_RESULT_VERSION;
     result->features = MESSAGE__FEATURE_CAPACITY;
 
-    /* Initialize field not set in rejection pathway */
-    result->last_log_index = 0;
-
     match = recvEnsureMatchingTerms(r, args->term);
 
     /* From Figure 3.1:
@@ -47,6 +44,7 @@ int recvAppendEntries(struct raft *r,
     if (match < 0) {
         infof("local term is higher (%llu vs %llu) -> reject", r->current_term,
               args->term);
+        result->last_log_index = 0;
         goto reply;
     }
 

--- a/src/recv_append_entries.c
+++ b/src/recv_append_entries.c
@@ -34,6 +34,9 @@ int recvAppendEntries(struct raft *r,
     result->version = MESSAGE__APPEND_ENTRIES_RESULT_VERSION;
     result->features = MESSAGE__FEATURE_CAPACITY;
 
+    /* Initialize field not set in rejection pathway */
+    result->last_log_index = 0;
+
     match = recvEnsureMatchingTerms(r, args->term);
 
     /* From Figure 3.1:

--- a/src/recv_install_snapshot.c
+++ b/src/recv_install_snapshot.c
@@ -26,6 +26,9 @@ int recvInstallSnapshot(struct raft *r,
     result->version = MESSAGE__APPEND_ENTRIES_RESULT_VERSION;
     result->features = MESSAGE__FEATURE_CAPACITY;
 
+    /* Initialize field not set in rejection pathway */
+    result->last_log_index = 0;
+
     match = recvEnsureMatchingTerms(r, args->term);
 
     if (match < 0) {

--- a/src/recv_install_snapshot.c
+++ b/src/recv_install_snapshot.c
@@ -26,14 +26,12 @@ int recvInstallSnapshot(struct raft *r,
     result->version = MESSAGE__APPEND_ENTRIES_RESULT_VERSION;
     result->features = MESSAGE__FEATURE_CAPACITY;
 
-    /* Initialize field not set in rejection pathway */
-    result->last_log_index = 0;
-
     match = recvEnsureMatchingTerms(r, args->term);
 
     if (match < 0) {
         infof("local term is higher (%llu vs %llu) -> reject", r->current_term,
               args->term);
+        result->last_log_index = 0;
         goto reply;
     }
 


### PR DESCRIPTION
In rejection pathways when receiving append entries or install snapshot frames, the `last_log_index` field of the internal representation of the append entries result frame was not set. This uninitialized value was then written to the encoding buffer for outgoing append entries result frame and sent out.