### PR TITLE
fix return type of raft_voted_for in raft.c

### DIFF
--- a/src/raft.c
+++ b/src/raft.c
@@ -589,7 +589,7 @@ raft_term raft_current_term(const struct raft *r)
     return r->current_term;
 }
 
-raft_term raft_voted_for(const struct raft *r)
+raft_id raft_voted_for(const struct raft *r)
 {
     return r->voted_for;
 }


### PR DESCRIPTION
Fix the return type of `raft_voted_for` to match the definition in the header.

https://github.com/cowsql/raft/blob/1f4ed2f38f9c0d2c35ca4b6f549f78142d8426a9/include/raft.h.in#L1047